### PR TITLE
Fix glasses SPP discovery and outbound routing

### DIFF
--- a/glasses-hub/src/main/java/com/anezium/rokidbus/glasses/GlassesHub.kt
+++ b/glasses-hub/src/main/java/com/anezium/rokidbus/glasses/GlassesHub.kt
@@ -784,13 +784,17 @@ object GlassesHub {
             return if (SppServerManager.send(envelope)) null else "NO_DATA_PLANE"
         }
         val bytes = FrameProtocol.toJsonBytes(envelope)
-        if (bytes.size <= BusConstants.CXR_CONTROL_MAX_BYTES && CxrBusBridge.isUp()) {
-            if (CxrBusBridge.send(envelope)) return null
+        GlassesOutboundTransportPolicy.order(
+            sppConnected = SppServerManager.isConnected(),
+            cxrUp = CxrBusBridge.isUp(),
+            payloadBytes = bytes.size,
+        ).forEach { transport ->
+            val sent = when (transport) {
+                GlassesOutboundTransport.SPP -> SppServerManager.send(envelope)
+                GlassesOutboundTransport.CXR -> CxrBusBridge.send(envelope)
+            }
+            if (sent) return null
         }
-        if (bytes.size > BusConstants.CXR_CONTROL_MAX_BYTES && !SppServerManager.isConnected()) {
-            return "NO_DATA_PLANE"
-        }
-        if (SppServerManager.send(envelope)) return null
         return if (bytes.size > BusConstants.CXR_CONTROL_MAX_BYTES) "NO_DATA_PLANE" else "NO_LINK"
     }
 

--- a/glasses-hub/src/main/java/com/anezium/rokidbus/glasses/GlassesOutboundTransportPolicy.kt
+++ b/glasses-hub/src/main/java/com/anezium/rokidbus/glasses/GlassesOutboundTransportPolicy.kt
@@ -1,0 +1,23 @@
+package com.anezium.rokidbus.glasses
+
+import com.anezium.rokidbus.shared.BusConstants
+
+internal enum class GlassesOutboundTransport {
+    SPP,
+    CXR,
+}
+
+internal object GlassesOutboundTransportPolicy {
+    fun order(
+        sppConnected: Boolean,
+        cxrUp: Boolean,
+        payloadBytes: Int,
+    ): List<GlassesOutboundTransport> = buildList {
+        // CXR can report a successful send even when its phone-side callback is not delivering.
+        // A live SPP socket has end-to-end framing and is therefore the reliable first choice.
+        if (sppConnected) add(GlassesOutboundTransport.SPP)
+        if (cxrUp && payloadBytes <= BusConstants.CXR_CONTROL_MAX_BYTES) {
+            add(GlassesOutboundTransport.CXR)
+        }
+    }
+}

--- a/glasses-hub/src/test/java/com/anezium/rokidbus/glasses/GlassesOutboundTransportPolicyTest.kt
+++ b/glasses-hub/src/test/java/com/anezium/rokidbus/glasses/GlassesOutboundTransportPolicyTest.kt
@@ -1,0 +1,55 @@
+package com.anezium.rokidbus.glasses
+
+import com.anezium.rokidbus.shared.BusConstants
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GlassesOutboundTransportPolicyTest {
+    @Test
+    fun `SPP is preferred when both transports are available`() {
+        assertEquals(
+            listOf(GlassesOutboundTransport.SPP, GlassesOutboundTransport.CXR),
+            GlassesOutboundTransportPolicy.order(
+                sppConnected = true,
+                cxrUp = true,
+                payloadBytes = 128,
+            ),
+        )
+    }
+
+    @Test
+    fun `CXR carries small control messages when SPP is unavailable`() {
+        assertEquals(
+            listOf(GlassesOutboundTransport.CXR),
+            GlassesOutboundTransportPolicy.order(
+                sppConnected = false,
+                cxrUp = true,
+                payloadBytes = 128,
+            ),
+        )
+    }
+
+    @Test
+    fun `oversized messages use only SPP`() {
+        assertEquals(
+            listOf(GlassesOutboundTransport.SPP),
+            GlassesOutboundTransportPolicy.order(
+                sppConnected = true,
+                cxrUp = true,
+                payloadBytes = BusConstants.CXR_CONTROL_MAX_BYTES + 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `no transport is selected when neither is usable`() {
+        assertEquals(
+            emptyList<GlassesOutboundTransport>(),
+            GlassesOutboundTransportPolicy.order(
+                sppConnected = false,
+                cxrUp = false,
+                payloadBytes = 128,
+            ),
+        )
+    }
+}

--- a/phone-hub/src/main/java/com/anezium/rokidbus/phone/BusHubService.kt
+++ b/phone-hub/src/main/java/com/anezium/rokidbus/phone/BusHubService.kt
@@ -119,8 +119,6 @@ private const val EXTRA_MANUAL_HOST = "manual_host"
 private const val EXTRA_MANUAL_PAIR_PORT = "manual_pair_port"
 private const val EXTRA_MANUAL_CODE = "manual_code"
 private const val PREF_ENABLED = "hub_enabled"
-private const val GLASSES_MAC = "AC:86:D1:55:1E:ED"
-private const val GLASSES_NAME = "Glasses_3723"
 private const val GLASSES_HUB_PACKAGE = "com.anezium.rokidbus.glasses"
 private const val PREFS = "rokidbus_phone"
 private const val PREF_TOKEN = "cxrl_token"
@@ -3431,8 +3429,15 @@ class BusHubService : Service() {
     @SuppressLint("MissingPermission")
     private fun pickBondedDevice(): BluetoothDevice? {
         val bonded = BluetoothAdapter.getDefaultAdapter()?.bondedDevices?.toList().orEmpty()
-        return bonded.firstOrNull { it.address.equals(GLASSES_MAC, ignoreCase = true) }
-            ?: bonded.firstOrNull { it.name.equals(GLASSES_NAME, ignoreCase = true) }
+        val selectedIndex = GlassesBondedDeviceSelector.pickIndex(
+            bonded.map { device ->
+                BondedBluetoothDevice(
+                    name = device.name,
+                    serviceUuids = device.uuids.orEmpty().map { it.uuid.toString() }.toSet(),
+                )
+            },
+        ) ?: return null
+        return bonded[selectedIndex]
     }
 
     private fun startCxrIfTokenAvailable() {
@@ -4423,9 +4428,7 @@ class BusHubService : Service() {
     @SuppressLint("MissingPermission")
     private fun isGlassesBonded(): Boolean =
         canRunHub(this) &&
-            BluetoothAdapter.getDefaultAdapter()?.bondedDevices.orEmpty().any {
-                it.address.equals(GLASSES_MAC, ignoreCase = true)
-            }
+            pickBondedDevice() != null
 
     private fun isCxrUp(): Boolean =
         cxrConnected && glassBtConnected && cxrLink?.isServiceConnected() == true

--- a/phone-hub/src/main/java/com/anezium/rokidbus/phone/BusHubService.kt
+++ b/phone-hub/src/main/java/com/anezium/rokidbus/phone/BusHubService.kt
@@ -119,6 +119,7 @@ private const val EXTRA_MANUAL_HOST = "manual_host"
 private const val EXTRA_MANUAL_PAIR_PORT = "manual_pair_port"
 private const val EXTRA_MANUAL_CODE = "manual_code"
 private const val PREF_ENABLED = "hub_enabled"
+private const val PREF_LAST_GLASSES_ADDRESS = "last_glasses_address"
 private const val GLASSES_HUB_PACKAGE = "com.anezium.rokidbus.glasses"
 private const val PREFS = "rokidbus_phone"
 private const val PREF_TOKEN = "cxrl_token"
@@ -3429,15 +3430,23 @@ class BusHubService : Service() {
     @SuppressLint("MissingPermission")
     private fun pickBondedDevice(): BluetoothDevice? {
         val bonded = BluetoothAdapter.getDefaultAdapter()?.bondedDevices?.toList().orEmpty()
+        val rememberedAddress = prefs().getString(PREF_LAST_GLASSES_ADDRESS, null)
         val selectedIndex = GlassesBondedDeviceSelector.pickIndex(
             bonded.map { device ->
                 BondedBluetoothDevice(
+                    address = device.address,
                     name = device.name,
+                    alias = device.alias,
                     serviceUuids = device.uuids.orEmpty().map { it.uuid.toString() }.toSet(),
                 )
             },
+            preferredAddress = rememberedAddress,
         ) ?: return null
-        return bonded[selectedIndex]
+        return bonded[selectedIndex].also { selected ->
+            if (!selected.address.equals(rememberedAddress, ignoreCase = true)) {
+                prefs().edit().putString(PREF_LAST_GLASSES_ADDRESS, selected.address).apply()
+            }
+        }
     }
 
     private fun startCxrIfTokenAvailable() {

--- a/phone-hub/src/main/java/com/anezium/rokidbus/phone/GlassesBondedDeviceSelector.kt
+++ b/phone-hub/src/main/java/com/anezium/rokidbus/phone/GlassesBondedDeviceSelector.kt
@@ -1,0 +1,26 @@
+package com.anezium.rokidbus.phone
+
+import com.anezium.rokidbus.shared.BusConstants
+
+internal data class BondedBluetoothDevice(
+    val name: String?,
+    val serviceUuids: Set<String>,
+)
+
+/** Identifies the paired Rokid unit without tying Nexus to one developer's glasses. */
+internal object GlassesBondedDeviceSelector {
+    fun pickIndex(devices: List<BondedBluetoothDevice>): Int? {
+        val sppUuid = BusConstants.SPP_UUID_STRING.lowercase()
+        val uuidMatch = devices.indexOfFirst { device ->
+            device.serviceUuids.any { it.equals(sppUuid, ignoreCase = true) }
+        }
+        if (uuidMatch >= 0) return uuidMatch
+
+        val nameMatch = devices.indexOfFirst { device ->
+            device.name?.startsWith(GLASSES_NAME_PREFIX, ignoreCase = true) == true
+        }
+        return nameMatch.takeIf { it >= 0 }
+    }
+
+    private const val GLASSES_NAME_PREFIX = "Glasses_"
+}

--- a/phone-hub/src/main/java/com/anezium/rokidbus/phone/GlassesBondedDeviceSelector.kt
+++ b/phone-hub/src/main/java/com/anezium/rokidbus/phone/GlassesBondedDeviceSelector.kt
@@ -3,13 +3,23 @@ package com.anezium.rokidbus.phone
 import com.anezium.rokidbus.shared.BusConstants
 
 internal data class BondedBluetoothDevice(
+    val address: String,
     val name: String?,
+    val alias: String?,
     val serviceUuids: Set<String>,
 )
 
 /** Identifies the paired Rokid unit without tying Nexus to one developer's glasses. */
 internal object GlassesBondedDeviceSelector {
-    fun pickIndex(devices: List<BondedBluetoothDevice>): Int? {
+    fun pickIndex(
+        devices: List<BondedBluetoothDevice>,
+        preferredAddress: String? = null,
+    ): Int? {
+        val rememberedMatch = preferredAddress?.let { address ->
+            devices.indexOfFirst { it.address.equals(address, ignoreCase = true) }
+        } ?: -1
+        if (rememberedMatch >= 0) return rememberedMatch
+
         val sppUuid = BusConstants.SPP_UUID_STRING.lowercase()
         val uuidMatch = devices.indexOfFirst { device ->
             device.serviceUuids.any { it.equals(sppUuid, ignoreCase = true) }
@@ -17,7 +27,9 @@ internal object GlassesBondedDeviceSelector {
         if (uuidMatch >= 0) return uuidMatch
 
         val nameMatch = devices.indexOfFirst { device ->
-            device.name?.startsWith(GLASSES_NAME_PREFIX, ignoreCase = true) == true
+            sequenceOf(device.alias, device.name)
+                .filterNotNull()
+                .any { it.startsWith(GLASSES_NAME_PREFIX, ignoreCase = true) }
         }
         return nameMatch.takeIf { it >= 0 }
     }

--- a/phone-hub/src/test/java/com/anezium/rokidbus/phone/GlassesBondedDeviceSelectorTest.kt
+++ b/phone-hub/src/test/java/com/anezium/rokidbus/phone/GlassesBondedDeviceSelectorTest.kt
@@ -1,0 +1,53 @@
+package com.anezium.rokidbus.phone
+
+import com.anezium.rokidbus.shared.BusConstants
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GlassesBondedDeviceSelectorTest {
+    @Test
+    fun `selects the device advertising the Nexus SPP service`() {
+        val devices = listOf(
+            device("Headphones", "0000110b-0000-1000-8000-00805f9b34fb"),
+            device("My Rokid", BusConstants.SPP_UUID_STRING.uppercase()),
+        )
+
+        assertEquals(1, GlassesBondedDeviceSelector.pickIndex(devices))
+    }
+
+    @Test
+    fun `falls back to the per-unit Rokid glasses name while UUIDs are unavailable`() {
+        val devices = listOf(
+            device("Google Pixel Watch"),
+            device("Glasses_1899"),
+        )
+
+        assertEquals(1, GlassesBondedDeviceSelector.pickIndex(devices))
+    }
+
+    @Test
+    fun `service UUID wins over a merely glasses-shaped name`() {
+        val devices = listOf(
+            device("Glasses_Other"),
+            device("Rokid unit", BusConstants.SPP_UUID_STRING),
+        )
+
+        assertEquals(1, GlassesBondedDeviceSelector.pickIndex(devices))
+    }
+
+    @Test
+    fun `does not claim unrelated bonded devices`() {
+        val devices = listOf(
+            device("Google Pixel Watch"),
+            device("Arctis GameBuds", "0000110b-0000-1000-8000-00805f9b34fb"),
+        )
+
+        assertNull(GlassesBondedDeviceSelector.pickIndex(devices))
+    }
+
+    private fun device(name: String, vararg serviceUuids: String) = BondedBluetoothDevice(
+        name = name,
+        serviceUuids = serviceUuids.toSet(),
+    )
+}

--- a/phone-hub/src/test/java/com/anezium/rokidbus/phone/GlassesBondedDeviceSelectorTest.kt
+++ b/phone-hub/src/test/java/com/anezium/rokidbus/phone/GlassesBondedDeviceSelectorTest.kt
@@ -27,6 +27,38 @@ class GlassesBondedDeviceSelectorTest {
     }
 
     @Test
+    fun `uses the persistent local alias while the remote name and UUID cache are unavailable`() {
+        val devices = listOf(
+            device("Google Pixel Watch"),
+            device(name = null, alias = "Glasses_1899"),
+        )
+
+        assertEquals(1, GlassesBondedDeviceSelector.pickIndex(devices))
+    }
+
+    @Test
+    fun `reuses a remembered address only while it remains bonded`() {
+        val devices = listOf(
+            device("Google Pixel Watch", address = "AA:BB:CC:DD:EE:01"),
+            device(name = null, address = "AA:BB:CC:DD:EE:02"),
+        )
+
+        assertEquals(
+            1,
+            GlassesBondedDeviceSelector.pickIndex(
+                devices,
+                preferredAddress = "aa:bb:cc:dd:ee:02",
+            ),
+        )
+        assertNull(
+            GlassesBondedDeviceSelector.pickIndex(
+                devices,
+                preferredAddress = "AA:BB:CC:DD:EE:03",
+            ),
+        )
+    }
+
+    @Test
     fun `service UUID wins over a merely glasses-shaped name`() {
         val devices = listOf(
             device("Glasses_Other"),
@@ -46,8 +78,15 @@ class GlassesBondedDeviceSelectorTest {
         assertNull(GlassesBondedDeviceSelector.pickIndex(devices))
     }
 
-    private fun device(name: String, vararg serviceUuids: String) = BondedBluetoothDevice(
+    private fun device(
+        name: String?,
+        vararg serviceUuids: String,
+        address: String = "00:00:00:00:00:00",
+        alias: String? = null,
+    ) = BondedBluetoothDevice(
+        address = address,
         name = name,
+        alias = alias,
         serviceUuids = serviceUuids.toSet(),
     )
 }


### PR DESCRIPTION
## Summary

- discover the paired glasses by the Nexus SPP service UUID, with the persistent local `Glasses_*` alias as a fallback when runtime Bluetooth metadata is unavailable
- remember the selected public BR/EDR address and reuse it only while Android still reports that address in the bonded set
- remove the hard-coded developer-specific Bluetooth address and glasses name
- prefer an active SPP socket for glasses-to-phone control traffic, while retaining CXR as the fallback for eligible payloads
- cover initial device selection, metadata loss, remembered-device reconnect, and outbound transport ordering with focused unit tests

## Root cause

The phone hub only recognized one hard-coded glasses address/name, so other paired Rokid units were ignored.

The first version of this fix still depended on the remote `BluetoothDevice.name` or SDP UUID cache on every reconnect. Those fields can become unavailable after an RFCOMM disconnect even though Android continues to report the same glasses as persistently bonded. Nexus then incorrectly logged `No bonded glasses device found` and never retried RFCOMM against the real bonded unit.

Separately, the glasses sent small outbound control messages through CXR first. CXR could report that a message was accepted even when its phone-side callback did not deliver it, preventing the working SPP connection from carrying messages such as capability announcements and launcher actions.

## User impact

Setup can complete with a normally bonded Rokid unit. SPP now reconnects after the glasses-side process/socket disappears, and selecting a synced plugin on the glasses reaches the phone over SPP.

Fixes #1

## Validation

- `:phone-hub:testDebugUnitTest --tests com.anezium.rokidbus.phone.GlassesBondedDeviceSelectorTest`
- `:glasses-hub:testDebugUnitTest --tests com.anezium.rokidbus.glasses.GlassesOutboundTransportPolicyTest`
- `:phone-hub:assembleRelease`
- `:glasses-hub:assembleRelease`
- reproduced the stale-metadata failure on a physical Pixel phone while Android still reported the Rokid unit as persistently bonded and BR/EDR connected
- installed the updated phone APK and observed SPP connect immediately from that same state
- force-stopped and restarted only the glasses hub process: the phone retried the failed RFCOMM socket and reconnected in about four seconds without reporting `No bonded glasses device found`
- after reconnect, `/system/hub/capabilities` arrived over SPP and `/launcher/open` round-tripped as SPP TX/RX before the plugin returned `/surface/show`
- force-stopped and restarted the phone hub process as well: persisted device selection survived the process death, RFCOMM reconnected after the stack released the stale socket, and no `No bonded glasses device found` state appeared
- subsequently opened the Shoplist and Taxi HUD plugins from the glasses; both `/launcher/open` requests arrived over SPP and returned their surfaces
