### PR TITLE
Add Polish to the forced transcription languages

### DIFF
--- a/phone-hub/src/main/java/com/anezium/rokidbus/phone/speech/TranscriptionLanguageConfig.kt
+++ b/phone-hub/src/main/java/com/anezium/rokidbus/phone/speech/TranscriptionLanguageConfig.kt
@@ -82,6 +82,15 @@ enum class TranscriptionLanguage(
         androidTag = "pt-BR",
         uiNote = "Azure and Android use the Brazilian locale (pt-BR).",
     ),
+    POLISH(
+        id = "pl",
+        label = "Polski",
+        summaryName = "Polish",
+        openAiCode = "pl",
+        elevenLabsCode = "pl",
+        azureLocale = "pl-PL",
+        androidTag = "pl-PL",
+    ),
     JAPANESE(
         id = "ja",
         label = "日本語",


### PR DESCRIPTION
Adds Polish to the forced-transcription language grid.

All four backends already support it natively: OpenAI (`pl`), ElevenLabs (`pl`), Azure (`pl-PL`), and the Android recognizer (`pl-PL`), so this is a single enum entry — the settings grid, wire protocol, and round-trip test all pick it up through `values()`/`entries`.

Validation note: I couldn't build `:phone-hub` locally (it needs the `CxrGlobal` sibling composite, which outside contributors don't have), but the entry is field-for-field identical in shape to the existing eleven languages and touches nothing else.

Happy to adjust anything — placement, label, or ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSgqqKbuXBTvyMzTHXzASk
