### PR TITLE
Auto-fit plain card bodies like timed lines

### DIFF
--- a/glasses-hub/src/main/java/com/anezium/rokidbus/glasses/SurfaceHudView.kt
+++ b/glasses-hub/src/main/java/com/anezium/rokidbus/glasses/SurfaceHudView.kt
@@ -626,7 +626,7 @@ class SurfaceHudView(context: Context) : LinearLayout(context) {
         private const val CARD_BODY_SP = 17f
         private const val CARD_BODY_MAX_LINES = 15
         private const val CARD_BODY_MAX_SP = 17
-        private const val CARD_BODY_MIN_SP = 12
+        private const val CARD_BODY_MIN_SP = 14
         private const val CARD_BODY_STEP_SP = 1
         private const val TIMED_BODY_SP = 25f
         private const val TIMED_BODY_MAX_LINES = 5

--- a/glasses-hub/src/main/java/com/anezium/rokidbus/glasses/SurfaceHudView.kt
+++ b/glasses-hub/src/main/java/com/anezium/rokidbus/glasses/SurfaceHudView.kt
@@ -163,6 +163,19 @@ class SurfaceHudView(context: Context) : LinearLayout(context) {
         nextView.visibility = visibleIf(nextView.text.isNotBlank())
     }
 
+    private fun fitCardBody() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            currentView.setAutoSizeTextTypeUniformWithConfiguration(
+                CARD_BODY_MIN_SP,
+                CARD_BODY_MAX_SP,
+                CARD_BODY_STEP_SP,
+                TypedValue.COMPLEX_UNIT_SP,
+            )
+        } else {
+            currentView.textSize = CARD_BODY_SP
+        }
+    }
+
     private fun fitTimedBody() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             currentView.setAutoSizeTextTypeUniformWithConfiguration(
@@ -439,10 +452,9 @@ class SurfaceHudView(context: Context) : LinearLayout(context) {
     private fun renderPlainCard(rows: List<SurfaceRow>) {
         boardView.visibility = GONE
         currentView.visibility = VISIBLE
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            currentView.setAutoSizeTextTypeWithDefaults(TextView.AUTO_SIZE_TEXT_TYPE_NONE)
-        }
-        currentView.textSize = CARD_BODY_SP
+        // Long card bodies (assistant replies, article text) must never lose
+        // their tail: shrink to fit instead of clipping, like timed lines do.
+        fitCardBody()
         currentView.maxLines = CARD_BODY_MAX_LINES
         // Plain cards align as a left block; per-line centering scatters the columns.
         currentView.gravity = Gravity.CENTER_VERTICAL or Gravity.START
@@ -609,8 +621,13 @@ class SurfaceHudView(context: Context) : LinearLayout(context) {
         private const val MEDIA_TICK_MS = 500L
 
         // Plain card bodies (messages, chooser): smaller mono, more lines.
+        // Auto-fit mirrors the lyrics pattern: short bodies keep the full
+        // size, long ones shrink to fit instead of clipping their tail.
         private const val CARD_BODY_SP = 17f
         private const val CARD_BODY_MAX_LINES = 15
+        private const val CARD_BODY_MAX_SP = 17
+        private const val CARD_BODY_MIN_SP = 12
+        private const val CARD_BODY_STEP_SP = 1
         private const val TIMED_BODY_SP = 25f
         private const val TIMED_BODY_MAX_LINES = 5
 


### PR DESCRIPTION
Plain cards render at a fixed 17 sp and clip at 15 lines, so text-heavy plugins (assistant replies, article bodies) silently lose the tail of long content.

This gives plain cards the same treatment `fitTimedBody()` already gives lyrics: uniform auto-size between 12 sp and 17 sp. Short bodies render pixel-identical to today (17 sp is both the old fixed size and the auto-size ceiling); only content that would have clipped shrinks to fit. Pre-O fallback keeps the fixed size, matching the timed-lines pattern.

Design note: I've read plan 015, where long notice bodies get true pagination measured in the renderer — clearly the richer answer for long content. This PR is deliberately the minimal bridge for plain cards in the meantime, reusing an existing mechanism rather than inventing anything. If card paging is the intended endgame, I'd genuinely enjoy helping build that instead — treat this as a stopgap or a conversation starter, whichever serves the roadmap. Happy to pitch in wherever it's useful.

`:glasses-hub:assembleDebug` builds clean. Not flashed to hardware — my glasses run the release hub — so a look from someone who can render it on-device would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSgqqKbuXBTvyMzTHXzASk
