### PR TITLE
Add the Food Log V3 health tracking plugin

### DIFF
--- a/plugins/foodlog/CHANGELOG.md
+++ b/plugins/foodlog/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Add local food history and daily calorie/macronutrient totals.
+- Add exact Open Food Facts barcode lookup and a local product cache.
+- Add glasses snapshot barcode scanning, portion selection, recent foods, and
+  exact undo confirmation.
+- Add a Nexus-styled phone journal with manual barcode entry and deletion.

--- a/plugins/foodlog/CHANGELOG.md
+++ b/plugins/foodlog/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## 0.1.0
+## 3.0.0
+
+- Add the phone nutrition dashboard, meal classification, daily goals,
+  micronutrients, and seven-day summaries.
+- Add custom foods, favorites, recipes, and reusable quick logging.
+- Add local glasses voice entry without retaining transcripts.
+- Add optional write-only Health Connect synchronization with stable record IDs,
+  update propagation, and exact deletion propagation while opted in.
+- Add explicit one-shot meal and hydration reminders with pause, resume, cancel,
+  boot restoration, and exact-alarm fallback.
+- Add complete, bounded V3 JSON archive export/import while retaining V2 journal
+  import compatibility.
+
+## 1.0.0
 
 - Add local food history and daily calorie/macronutrient totals.
 - Add exact Open Food Facts barcode lookup and a local product cache.

--- a/plugins/foodlog/README.md
+++ b/plugins/foodlog/README.md
@@ -1,14 +1,31 @@
 # Food Log plugin
 
-Food Log is a local-first nutrition journal for Rokid Nexus. From the glasses,
-scan an EAN/UPC barcode, review the Open Food Facts product, choose the amount,
-and add it to today's log. The phone settings screen supports manual barcode
-lookup, history review, exact-entry deletion, and local daily totals.
+Food Log 3 is a local-first nutrition and meal journal for Rokid Nexus.
 
-Product reads use the Open Food Facts API. Each consumed entry stores its own
-nutrition snapshot so later community edits cannot rewrite the wearer's
-history. Unknown nutrient values remain unknown rather than being treated as
-zero. No food history is uploaded by the plugin.
+On the glasses it can scan an EAN/UPC barcode, resolve the exact product through
+Open Food Facts, accept a portion, add recent or favorite foods and recipes, take
+a local voice entry, display today's totals, and undo the exact last entry.
+
+The phone dashboard adds:
+
+- meal classification, daily goals, micronutrients, and seven-day summaries;
+- custom foods, favorites, recipes, and their reusable nutrition snapshots;
+- exact manual barcode lookup plus a link to contribute missing products to
+  Open Food Facts;
+- optional, write-only Health Connect synchronization;
+- explicit one-shot meal or hydration reminders with pause, resume, and cancel;
+- a bounded JSON V3 archive containing entries, the product catalog, favorites,
+  goals, recipes, and reminders. V2 journal-only backups remain importable.
+
+Each consumed entry stores its own nutrition snapshot, so later community or
+catalog edits cannot rewrite history. Unknown nutrient values stay unknown rather
+than becoming zero. Food history, favorites, goals, and recipes remain on the
+phone unless the wearer explicitly exports a backup or enables Health Connect.
+Voice matching is local against stored products and transcripts are never logged.
+
+Open Food Facts data is collaborative and can be incomplete. The package label
+remains the source to check when nutrition data matters; Food Log is a tracking
+tool, not a medical device.
 
 ```bash
 ./gradlew :plugin-foodlog:testDebugUnitTest :plugin-foodlog:assembleDebug -PskipCxrGlobal=true

--- a/plugins/foodlog/README.md
+++ b/plugins/foodlog/README.md
@@ -1,0 +1,15 @@
+# Food Log plugin
+
+Food Log is a local-first nutrition journal for Rokid Nexus. From the glasses,
+scan an EAN/UPC barcode, review the Open Food Facts product, choose the amount,
+and add it to today's log. The phone settings screen supports manual barcode
+lookup, history review, exact-entry deletion, and local daily totals.
+
+Product reads use the Open Food Facts API. Each consumed entry stores its own
+nutrition snapshot so later community edits cannot rewrite the wearer's
+history. Unknown nutrient values remain unknown rather than being treated as
+zero. No food history is uploaded by the plugin.
+
+```bash
+./gradlew :plugin-foodlog:testDebugUnitTest :plugin-foodlog:assembleDebug -PskipCxrGlobal=true
+```

--- a/plugins/foodlog/build.gradle.kts
+++ b/plugins/foodlog/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "com.anezium.rokidbus.plugin.foodlog"
         minSdk = 30
         targetSdk = 36
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = 3
+        versionName = "3.0.0"
     }
 
     compileOptions {
@@ -24,6 +24,8 @@ android {
 
 dependencies {
     implementation(project(":bus-client"))
+    implementation("androidx.health.connect:connect-client:1.1.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("com.google.mlkit:barcode-scanning:17.3.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.json:json:20240303")

--- a/plugins/foodlog/build.gradle.kts
+++ b/plugins/foodlog/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    id("com.android.application")
+}
+
+apply(from = rootProject.file("gradle/plugin-release-signing.gradle"))
+
+android {
+    namespace = "com.anezium.rokidbus.plugin.foodlog"
+    compileSdk = 36
+
+    defaultConfig {
+        applicationId = "com.anezium.rokidbus.plugin.foodlog"
+        minSdk = 30
+        targetSdk = 36
+        versionCode = 1
+        versionName = "0.1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+dependencies {
+    implementation(project(":bus-client"))
+    implementation("com.google.mlkit:barcode-scanning:17.3.0")
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.json:json:20240303")
+}

--- a/plugins/foodlog/src/main/AndroidManifest.xml
+++ b/plugins/foodlog/src/main/AndroidManifest.xml
@@ -5,10 +5,15 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
-    <!-- No phone-camera or notification permission: capture belongs to the
-         explicitly granted glasses-camera snapshot session. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.health.WRITE_NUTRITION" />
+    <!-- No phone-camera permission: capture belongs to the explicitly granted
+         glasses-camera snapshot session. Notification access is reminder-only. -->
 
     <queries>
+        <package android:name="com.google.android.apps.healthdata" />
         <intent>
             <action android:name="com.anezium.rokidbus.action.HUB" />
         </intent>
@@ -26,6 +31,44 @@
             android:name=".FoodLogActivity"
             android:exported="true"
             android:windowSoftInputMode="adjustResize" />
+
+        <activity
+            android:name=".FoodLogHealthRationaleActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
+        </activity>
+
+        <activity-alias
+            android:name=".FoodLogViewPermissionUsageActivity"
+            android:exported="true"
+            android:permission="android.permission.START_VIEW_PERMISSION_USAGE"
+            android:targetActivity=".FoodLogHealthRationaleActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity-alias>
+
+        <receiver
+            android:name=".FoodLogReminderReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.anezium.rokidbus.plugin.foodlog.action.REMINDER_FIRE" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name=".FoodLogReminderDeliveryService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="scheduled-food-log-reminder" />
+        </service>
 
         <service
             android:name=".FoodLogPluginService"

--- a/plugins/foodlog/src/main/AndroidManifest.xml
+++ b/plugins/foodlog/src/main/AndroidManifest.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <!-- No phone-camera or notification permission: capture belongs to the
+         explicitly granted glasses-camera snapshot session. -->
+
+    <queries>
+        <intent>
+            <action android:name="com.anezium.rokidbus.action.HUB" />
+        </intent>
+    </queries>
+
+    <application
+        android:allowBackup="false"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.FoodLog">
+
+        <activity
+            android:name=".FoodLogActivity"
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize" />
+
+        <service
+            android:name=".FoodLogPluginService"
+            android:exported="true"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="glasses-session" />
+            <intent-filter>
+                <action android:name="com.anezium.rokidbus.action.PLUGIN" />
+            </intent-filter>
+            <meta-data
+                android:name="com.anezium.rokidbus.plugin.ID"
+                android:value="foodlog" />
+            <meta-data
+                android:name="com.anezium.rokidbus.plugin.DISPLAY_NAME"
+                android:value="Food Log" />
+            <meta-data
+                android:name="com.anezium.rokidbus.plugin.ICON"
+                android:value="heart" />
+            <meta-data
+                android:name="com.anezium.rokidbus.plugin.API_VERSION"
+                android:value="3" />
+            <meta-data
+                android:name="com.anezium.rokidbus.plugin.CAPABILITIES"
+                android:value="surfaces,camera" />
+            <meta-data
+                android:name="com.anezium.rokidbus.plugin.RECEIVE_PREFIXES"
+                android:value="/plugin/foodlog,/system/plugin,/camera/snapshot/result,/camera/snapshot/error" />
+            <meta-data
+                android:name="com.anezium.rokidbus.plugin.SETTINGS_ACTIVITY"
+                android:value=".FoodLogActivity" />
+            <meta-data
+                android:name="com.anezium.rokidbus.plugin.LAUNCHABLE"
+                android:value="true" />
+        </service>
+    </application>
+</manifest>

--- a/plugins/foodlog/src/main/AndroidManifest.xml
+++ b/plugins/foodlog/src/main/AndroidManifest.xml
@@ -51,10 +51,10 @@
                 android:value="3" />
             <meta-data
                 android:name="com.anezium.rokidbus.plugin.CAPABILITIES"
-                android:value="surfaces,camera" />
+                android:value="surfaces,camera,stt" />
             <meta-data
                 android:name="com.anezium.rokidbus.plugin.RECEIVE_PREFIXES"
-                android:value="/plugin/foodlog,/system/plugin,/camera/snapshot/result,/camera/snapshot/error" />
+                android:value="/plugin/foodlog,/system/plugin,/camera/snapshot/result,/camera/snapshot/error,/stt" />
             <meta-data
                 android:name="com.anezium.rokidbus.plugin.SETTINGS_ACTIVITY"
                 android:value=".FoodLogActivity" />

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodBarcodeScanner.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodBarcodeScanner.kt
@@ -1,10 +1,10 @@
 package com.anezium.rokidbus.plugin.foodlog
 
 import android.graphics.BitmapFactory
-import com.google.mlkit.vision.barcode.Barcode
 import com.google.mlkit.vision.barcode.BarcodeScanner
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.common.InputImage
 import java.io.Closeable
 import java.util.concurrent.Executor

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodBarcodeScanner.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodBarcodeScanner.kt
@@ -1,0 +1,117 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import android.graphics.BitmapFactory
+import com.google.mlkit.vision.barcode.Barcode
+import com.google.mlkit.vision.barcode.BarcodeScanner
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.common.InputImage
+import java.io.Closeable
+import java.util.concurrent.Executor
+
+/**
+ * Decodes food barcodes from a JPEG snapshot.
+ *
+ * The supplied [callbackExecutor] owns all decoding work and callback delivery. Callers should
+ * keep it alive until callbacks have completed, then shut it down if they own its lifecycle.
+ */
+internal class FoodBarcodeScanner(
+    private val callbackExecutor: Executor,
+) : Closeable {
+
+    sealed interface Result {
+        data class Found(val code: String) : Result
+        data object NotFound : Result
+        data class Ambiguous(val codes: List<String>) : Result
+        data class Failure(val cause: Throwable) : Result
+    }
+
+    @Volatile
+    private var closed = false
+
+    /**
+     * Starts an asynchronous scan. [callback] is always invoked on [callbackExecutor].
+     */
+    fun scan(jpeg: ByteArray, callback: (Result) -> Unit) {
+        callbackExecutor.execute {
+            if (closed) {
+                callback(Result.Failure(IllegalStateException("Food barcode scanner is closed")))
+                return@execute
+            }
+            if (jpeg.isEmpty()) {
+                callback(Result.NotFound)
+                return@execute
+            }
+
+            val bitmap = runCatching {
+                BitmapFactory.decodeByteArray(jpeg, 0, jpeg.size)
+            }.getOrElse {
+                callback(Result.Failure(it))
+                return@execute
+            } ?: run {
+                callback(Result.NotFound)
+                return@execute
+            }
+
+            val scanner = BarcodeScanning.getClient(options)
+            try {
+                scanner.process(InputImage.fromBitmap(bitmap, 0))
+                    .addOnSuccessListener(callbackExecutor) { barcodes ->
+                        finish(scanner, bitmap) {
+                            callback(resultFor(barcodes))
+                        }
+                    }
+                    .addOnFailureListener(callbackExecutor) { error ->
+                        finish(scanner, bitmap) {
+                            callback(Result.Failure(error))
+                        }
+                    }
+            } catch (error: Throwable) {
+                finish(scanner, bitmap) {
+                    callback(Result.Failure(error))
+                }
+            }
+        }
+    }
+
+    override fun close() {
+        closed = true
+    }
+
+    private fun finish(
+        scanner: BarcodeScanner,
+        bitmap: android.graphics.Bitmap,
+        deliver: () -> Unit,
+    ) {
+        try {
+            deliver()
+        } finally {
+            scanner.close()
+            if (!bitmap.isRecycled) bitmap.recycle()
+        }
+    }
+
+    private fun resultFor(barcodes: List<Barcode>): Result {
+        val codes = barcodes.asSequence()
+            .mapNotNull { normalizeBarcode(it.rawValue.orEmpty()) }
+            .distinct()
+            .toList()
+        return when (codes.size) {
+            0 -> Result.NotFound
+            1 -> Result.Found(codes.single())
+            else -> Result.Ambiguous(codes)
+        }
+    }
+
+    private companion object {
+        val options: BarcodeScannerOptions = BarcodeScannerOptions.Builder()
+            .setBarcodeFormats(
+                Barcode.FORMAT_EAN_8,
+                Barcode.FORMAT_EAN_13,
+                Barcode.FORMAT_UPC_A,
+                Barcode.FORMAT_UPC_E,
+                Barcode.FORMAT_ITF,
+            )
+            .build()
+    }
+}

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodFactsClient.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodFactsClient.kt
@@ -1,0 +1,105 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import org.json.JSONObject
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Locale
+
+internal class FoodFactsClient(
+    private val baseUrl: String = "https://world.openfoodfacts.org/api/v3",
+    private val nowMillis: () -> Long = System::currentTimeMillis,
+    private val http: (String) -> String? = ::getProductJson,
+) {
+    fun product(barcode: String): FoodProduct? {
+        val normalized = normalizeBarcode(barcode) ?: return null
+        val fields = PRODUCT_FIELDS.joinToString(",")
+        val json = http("$baseUrl/product/$normalized?fields=$fields") ?: return null
+        return parseProduct(json, normalized, nowMillis())
+    }
+
+    companion object {
+        const val USER_AGENT =
+            "RokidNexusFoodLog/0.1 (https://github.com/Anezium/Rokid-Nexus)"
+
+        private val PRODUCT_FIELDS = listOf(
+            "code",
+            "product_name",
+            "generic_name",
+            "brands",
+            "serving_size",
+            "serving_quantity",
+            "serving_quantity_unit",
+            "nutrition_grades",
+            "nova_group",
+            "nutriments",
+        )
+
+        fun parseProduct(json: String, fallbackBarcode: String, fetchedAtMillis: Long): FoodProduct? {
+            val root = JSONObject(json)
+            val product = root.optJSONObject("product") ?: return null
+            val barcode = normalizeBarcode(product.optString("code").ifBlank { fallbackBarcode })
+                ?: return null
+            val name = product.optString("product_name")
+                .ifBlank { product.optString("generic_name") }
+                .ifBlank { "Product $barcode" }
+                .trim()
+            val servingUnit = product.optString("serving_quantity_unit").lowercase(Locale.US)
+            val servingGrams = product.optionalDouble("serving_quantity")
+                ?.takeIf { servingUnit.isBlank() || servingUnit == "g" }
+            val nutriments = product.optJSONObject("nutriments") ?: JSONObject()
+            return FoodProduct(
+                barcode = barcode,
+                name = name,
+                brand = product.optString("brands").trim(),
+                servingLabel = product.optString("serving_size").trim().takeIf(String::isNotBlank),
+                servingGrams = servingGrams,
+                nutritionGrade = product.optString("nutrition_grades")
+                    .trim()
+                    .takeIf(String::isNotBlank),
+                novaGroup = product.optionalInt("nova_group")?.takeIf { it in 1..4 },
+                nutrients = NutrientsPer100g(
+                    caloriesKcal = nutriments.optionalDouble("energy-kcal_100g"),
+                    proteinGrams = nutriments.optionalDouble("proteins_100g"),
+                    carbohydrateGrams = nutriments.optionalDouble("carbohydrates_100g"),
+                    fatGrams = nutriments.optionalDouble("fat_100g"),
+                    sugarsGrams = nutriments.optionalDouble("sugars_100g"),
+                    fiberGrams = nutriments.optionalDouble("fiber_100g"),
+                    saltGrams = nutriments.optionalDouble("salt_100g"),
+                ),
+                fetchedAtMillis = fetchedAtMillis,
+            )
+        }
+    }
+}
+
+private fun JSONObject.optionalDouble(name: String): Double? {
+    if (!has(name) || isNull(name)) return null
+    val value = optDouble(name, Double.NaN)
+    return value.takeIf { it.isFinite() && it >= 0.0 }
+}
+
+private fun JSONObject.optionalInt(name: String): Int? {
+    if (!has(name) || isNull(name)) return null
+    return optInt(name).takeIf { it != 0 }
+}
+
+private fun getProductJson(urlText: String): String? {
+    val connection = (URL(urlText).openConnection() as HttpURLConnection).apply {
+        connectTimeout = 10_000
+        readTimeout = 10_000
+        requestMethod = "GET"
+        setRequestProperty("Accept", "application/json")
+        setRequestProperty("User-Agent", FoodFactsClient.USER_AGENT)
+    }
+    return try {
+        val status = connection.responseCode
+        if (status == HttpURLConnection.HTTP_NOT_FOUND) return null
+        val stream = if (status in 200..299) connection.inputStream else connection.errorStream
+        val body = stream?.bufferedReader(Charsets.UTF_8)?.use { it.readText() }.orEmpty()
+        if (status !in 200..299) throw IOException("Open Food Facts HTTP $status")
+        body
+    } finally {
+        connection.disconnect()
+    }
+}

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodFactsClient.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodFactsClient.kt
@@ -66,6 +66,13 @@ internal class FoodFactsClient(
                     sugarsGrams = nutriments.optionalDouble("sugars_100g"),
                     fiberGrams = nutriments.optionalDouble("fiber_100g"),
                     saltGrams = nutriments.optionalDouble("salt_100g"),
+                    saturatedFatGrams = nutriments.optionalDouble("saturated-fat_100g"),
+                    sodiumMilligrams = nutriments.optionalGramsAsMilligrams("sodium_100g"),
+                    cholesterolMilligrams = nutriments.optionalGramsAsMilligrams("cholesterol_100g"),
+                    potassiumMilligrams = nutriments.optionalGramsAsMilligrams("potassium_100g"),
+                    calciumMilligrams = nutriments.optionalGramsAsMilligrams("calcium_100g"),
+                    ironMilligrams = nutriments.optionalGramsAsMilligrams("iron_100g"),
+                    caffeineMilligrams = nutriments.optionalGramsAsMilligrams("caffeine_100g"),
                 ),
                 fetchedAtMillis = fetchedAtMillis,
             )
@@ -83,6 +90,9 @@ private fun JSONObject.optionalInt(name: String): Int? {
     if (!has(name) || isNull(name)) return null
     return optInt(name).takeIf { it != 0 }
 }
+
+private fun JSONObject.optionalGramsAsMilligrams(name: String): Double? =
+    optionalDouble(name)?.times(1_000.0)
 
 private fun getProductJson(urlText: String): String? {
     val connection = (URL(urlText).openConnection() as HttpURLConnection).apply {

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogActivity.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogActivity.kt
@@ -1,68 +1,253 @@
 package com.anezium.rokidbus.plugin.foodlog
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
+import android.provider.Settings
 import android.text.InputType
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import android.widget.Button
 import android.widget.EditText
 import android.widget.LinearLayout
+import android.widget.Switch
 import android.widget.TextView
 import com.anezium.rokidbus.client.ui.BusTheme
 import com.anezium.rokidbus.client.ui.NexusPluginIcons
 import com.anezium.rokidbus.client.ui.NexusUi
+import androidx.health.connect.client.PermissionController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.Instant
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-/** Phone-side daily journal and manual barcode fallback for Food Log. */
+/** Phone-side dashboard and management surface for the local Food Log journal. */
 class FoodLogActivity : Activity() {
     private lateinit var store: FoodLogStore
     private val factsClient = FoodFactsClient()
     private val worker: ExecutorService = Executors.newSingleThreadExecutor()
-    private val main = Handler(Looper.getMainLooper())
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val healthBridge by lazy { FoodLogHealthConnectBridge(applicationContext) }
+    private val healthPermissionContract by lazy {
+        PermissionController.createRequestPermissionResultContract()
+    }
+    private val preferences by lazy {
+        getSharedPreferences(FOOD_LOG_PREFERENCES, MODE_PRIVATE)
+    }
+
+    private lateinit var summary: TextView
+    private lateinit var status: TextView
+    private lateinit var entriesList: LinearLayout
+    private lateinit var favoritesList: LinearLayout
+    private lateinit var recipesList: LinearLayout
+    private lateinit var weeklyList: LinearLayout
+    private lateinit var remindersList: LinearLayout
+    private lateinit var productCatalog: LinearLayout
 
     private lateinit var barcodeField: EditText
     private lateinit var quantityField: EditText
+    private lateinit var mealButton: Button
     private lateinit var addButton: View
-    private lateinit var lookupStatus: TextView
-    private lateinit var summary: TextView
-    private lateinit var entriesList: LinearLayout
+    private lateinit var contributionButton: Button
+
+    private lateinit var customNameField: EditText
+    private lateinit var customCaloriesField: EditText
+    private lateinit var customProteinField: EditText
+    private lateinit var customCarbsField: EditText
+    private lateinit var customFatField: EditText
+    private lateinit var customSaturatedFatField: EditText
+    private lateinit var customSodiumField: EditText
+    private lateinit var customPotassiumField: EditText
+    private lateinit var customCalciumField: EditText
+    private lateinit var customIronField: EditText
+    private lateinit var customCaffeineField: EditText
+    private lateinit var customCholesterolField: EditText
+
+    private lateinit var recipeNameField: EditText
+    private lateinit var recipeServingsField: EditText
+    private lateinit var recipeIngredientsField: EditText
+
+    private lateinit var goalCaloriesField: EditText
+    private lateinit var goalProteinField: EditText
+    private lateinit var goalCarbsField: EditText
+    private lateinit var goalFatField: EditText
+
+    private lateinit var healthSwitch: Switch
+    private lateinit var healthStatus: TextView
+    private var updatingHealthSwitch = false
+    private var healthConsentGeneration = 0L
+    private var pendingHealthPermissionGeneration: Long? = null
+
+    private lateinit var reminderLabelField: EditText
+    private lateinit var reminderMinutesField: EditText
+    private lateinit var reminderKindButton: Button
+
+    private var selectedMeal = inferredMealType(System.currentTimeMillis())
+    private var reminderKind = FoodLogReminderKind.MEAL
+    private var missingBarcode: String? = null
     private var destroyed = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         store = FoodLogStore(applicationContext)
         buildUi()
-        refreshDay()
+        refreshAll()
+        refreshHealthState()
     }
 
     override fun onDestroy() {
         destroyed = true
-        main.removeCallbacksAndMessages(null)
+        scope.cancel()
         worker.shutdownNow()
         if (::store.isInitialized) store.close()
         super.onDestroy()
     }
 
+    @Deprecated("Deprecated in Android; retained for document and Health Connect contracts.")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        when (requestCode) {
+            REQUEST_HEALTH_PERMISSION -> {
+                val granted = healthPermissionContract.parseResult(resultCode, data)
+                    .contains(FoodLogHealthConnectBridge.WRITE_NUTRITION_PERMISSION)
+                val requestGeneration = pendingHealthPermissionGeneration
+                pendingHealthPermissionGeneration = null
+                val accepted = granted && requestGeneration != null && requestGeneration == healthConsentGeneration
+                preferences.edit().putBoolean(FOOD_LOG_HEALTH_SYNC_KEY, accepted).apply()
+                report(if (accepted) "Health Connect sync enabled." else "Health Connect permission was not granted or sync was turned off.")
+                refreshHealthState()
+            }
+            REQUEST_EXPORT -> data?.data?.let(::writeBackup)
+            REQUEST_IMPORT -> data?.data?.let(::readBackup)
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_NOTIFICATIONS) {
+            report(
+                if (grantResults.firstOrNull() == PackageManager.PERMISSION_GRANTED) {
+                    "Reminder notifications enabled."
+                } else {
+                    "Reminder saved; phone notifications are disabled."
+                },
+            )
+        }
+    }
+
     private fun buildUi() {
         window.statusBarColor = NexusUi.BG
         window.navigationBarColor = NexusUi.BG
-        barcodeField = NexusUi.field(this, "Barcode").apply {
-            inputType = InputType.TYPE_CLASS_NUMBER
-            imeOptions = EditorInfo.IME_ACTION_NEXT
+        summary = NexusUi.cardBody(this, "Loading today’s journal…")
+        status = NexusUi.statusLine(this).apply { visibility = View.GONE }
+        entriesList = verticalList()
+        favoritesList = verticalList()
+        recipesList = verticalList()
+        weeklyList = verticalList()
+        remindersList = verticalList()
+        productCatalog = verticalList()
+        buildQuickAddControls()
+        buildCustomFoodControls()
+        buildRecipeControls()
+        buildGoalControls()
+        buildHealthControls()
+        buildReminderControls()
+
+        val content = NexusUi.contentColumn(this).apply {
+            introAndToday()
+            section(this, "Quick add", quickAddCard())
+            section(this, "Favorites", favoritesList)
+            section(this, "Entries", entriesList)
+            section(this, "7-day statistics", weeklyList)
+            section(this, "Goals", goalsCard())
+            section(this, "Custom food", customFoodCard())
+            section(this, "Recipes", recipesCard(), recipesList)
+            section(this, "Product IDs for recipes", productCatalog)
+            section(this, "Health Connect", healthCard())
+            section(this, "Reminders", remindersCard(), remindersList)
+            section(this, "Backup", backupCard())
+            section(
+                this,
+                "Data",
+                NexusUi.cardBody(
+                    this@FoodLogActivity,
+                    "Food history and recipes stay on this phone. Open Food Facts is collaborative and can be incomplete; check the package label when nutrition data matters.",
+                ),
+            )
+            section(this, "Plugin", uninstallRow())
         }
-        quantityField = NexusUi.field(this, "Quantity in grams").apply {
-            inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
-            imeOptions = EditorInfo.IME_ACTION_DONE
+        setContentView(
+            NexusUi.fixedRoot(this).apply {
+                addView(
+                    NexusUi.pluginHeader(
+                        this@FoodLogActivity,
+                        NexusPluginIcons.drawableFor("heart"),
+                        "Food Log",
+                        "Local nutrition journal · v0.3",
+                    ),
+                    NexusUi.block(),
+                )
+                addView(
+                    NexusUi.screen(this@FoodLogActivity, content),
+                    LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f),
+                )
+            },
+        )
+    }
+
+    private fun LinearLayout.introAndToday() {
+        addView(
+            NexusUi.cardBody(
+                this@FoodLogActivity,
+                "Scan from the glasses, add by voice, or manage a complete food journal here.",
+            ),
+            NexusUi.block(),
+        )
+        addView(BusTheme.gap(this@FoodLogActivity, 18))
+        addView(NexusUi.sectionRow(this@FoodLogActivity, "Today"), NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(NexusUi.card(this@FoodLogActivity).apply { addView(summary) }, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(status, NexusUi.block())
+    }
+
+    private fun section(
+        parent: LinearLayout,
+        title: String,
+        vararg views: View,
+    ) {
+        parent.addView(BusTheme.gap(this, 24))
+        parent.addView(NexusUi.sectionRow(this, title), NexusUi.block())
+        parent.addView(BusTheme.gap(this, 10))
+        views.forEachIndexed { index, view ->
+            if (index > 0) parent.addView(BusTheme.gap(this, 8))
+            parent.addView(view, NexusUi.block())
+        }
+    }
+
+    private fun buildQuickAddControls() {
+        barcodeField = textField("Barcode")
+        quantityField = numberField("Quantity in grams").apply {
             setText(DEFAULT_QUANTITY_GRAMS)
+            imeOptions = EditorInfo.IME_ACTION_DONE
             setOnEditorActionListener { _, actionId, _ ->
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
                     addFromBarcode()
@@ -72,190 +257,1025 @@ class FoodLogActivity : Activity() {
                 }
             }
         }
-        lookupStatus = NexusUi.statusLine(this).apply { visibility = View.GONE }
-        summary = NexusUi.cardBody(this, "Loading today’s journal…")
-        entriesList = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        mealButton = NexusUi.outlinePillButton(this, selectedMeal.displayName).apply {
+            setOnClickListener { cycleMeal() }
+        }
         addButton = NexusUi.pillButton(this, "Look up and add").apply {
             setOnClickListener { addFromBarcode() }
         }
-
-        val content = NexusUi.contentColumn(this).apply {
-            addView(
-                NexusUi.cardBody(
-                    this@FoodLogActivity,
-                    "Log packaged food by barcode. Product data comes from Open Food Facts and can be incomplete.",
-                ),
-                NexusUi.block(),
-            )
-            addView(BusTheme.gap(this@FoodLogActivity, 18))
-            addView(NexusUi.sectionRow(this@FoodLogActivity, "Today"), NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 10))
-            addView(NexusUi.card(this@FoodLogActivity).apply { addView(summary) }, NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 22))
-            addView(NexusUi.sectionRow(this@FoodLogActivity, "Add food"), NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 10))
-            addView(barcodeField, NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 8))
-            addView(quantityField, NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 10))
-            addView(addButton, NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 8))
-            addView(lookupStatus, NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 22))
-            addView(NexusUi.sectionRow(this@FoodLogActivity, "Entries"), NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 10))
-            addView(entriesList, NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 24))
-            addView(NexusUi.sectionRow(this@FoodLogActivity, "Data"), NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 10))
-            addView(
-                NexusUi.cardBody(
-                    this@FoodLogActivity,
-                    "Open Food Facts is a collaborative database. Check the label when nutrition data matters.",
-                ),
-                NexusUi.block(),
-            )
-            addView(BusTheme.gap(this@FoodLogActivity, 24))
-            addView(NexusUi.sectionRow(this@FoodLogActivity, "Plugin"), NexusUi.block())
-            addView(BusTheme.gap(this@FoodLogActivity, 10))
-            addView(uninstallRow(), NexusUi.block())
+        contributionButton = NexusUi.outlinePillButton(this, "Add product to Open Food Facts").apply {
+            visibility = View.GONE
+            setOnClickListener { missingBarcode?.let(::openFoodFactsContribution) }
         }
-        setContentView(NexusUi.fixedRoot(this).apply {
-            addView(
-                NexusUi.pluginHeader(
-                    this@FoodLogActivity,
-                    NexusPluginIcons.drawableFor("heart"),
-                    "Food Log",
-                    "Daily nutrition journal · v0.1",
-                ),
-                NexusUi.block(),
-            )
-            addView(
-                NexusUi.screen(this@FoodLogActivity, content),
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f),
-            )
-        })
+    }
+
+    private fun quickAddCard(): LinearLayout = NexusUi.card(this).apply {
+        addView(barcodeField, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(quantityField, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(mealButton, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(addButton, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(contributionButton, NexusUi.block())
+    }
+
+    private fun buildCustomFoodControls() {
+        customNameField = textField("Food name")
+        customCaloriesField = numberField("Calories / 100 g")
+        customProteinField = numberField("Protein g / 100 g")
+        customCarbsField = numberField("Carbohydrate g / 100 g")
+        customFatField = numberField("Fat g / 100 g")
+        customSaturatedFatField = numberField("Saturated fat g / 100 g (optional)")
+        customSodiumField = numberField("Sodium mg / 100 g (optional)")
+        customPotassiumField = numberField("Potassium mg / 100 g (optional)")
+        customCalciumField = numberField("Calcium mg / 100 g (optional)")
+        customIronField = numberField("Iron mg / 100 g (optional)")
+        customCaffeineField = numberField("Caffeine mg / 100 g (optional)")
+        customCholesterolField = numberField("Cholesterol mg / 100 g (optional)")
+    }
+
+    private fun customFoodCard(): LinearLayout = NexusUi.card(this).apply {
+        listOf(
+            customNameField,
+            customCaloriesField,
+            customProteinField,
+            customCarbsField,
+            customFatField,
+            customSaturatedFatField,
+            customSodiumField,
+            customPotassiumField,
+            customCalciumField,
+            customIronField,
+            customCaffeineField,
+            customCholesterolField,
+        ).forEachIndexed { index, field ->
+            if (index > 0) addView(BusTheme.gap(this@FoodLogActivity, 8))
+            addView(field, NexusUi.block())
+        }
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(
+            NexusUi.pillButton(this@FoodLogActivity, "Save custom food").apply {
+                setOnClickListener { saveCustomFood() }
+            },
+            NexusUi.block(),
+        )
+    }
+
+    private fun buildRecipeControls() {
+        recipeNameField = textField("Recipe name")
+        recipeServingsField = numberField("Number of servings").apply { setText("2") }
+        recipeIngredientsField = textField("product-id:grams; product-id:grams")
+    }
+
+    private fun recipesCard(): LinearLayout = NexusUi.card(this).apply {
+        addView(
+            NexusUi.cardBody(
+                this@FoodLogActivity,
+                "Use product IDs listed below. Example: 3017620422003:40; custom-…:120",
+            ),
+        )
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(recipeNameField, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(recipeServingsField, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(recipeIngredientsField, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(
+            NexusUi.pillButton(this@FoodLogActivity, "Save recipe").apply {
+                setOnClickListener { saveRecipe() }
+            },
+            NexusUi.block(),
+        )
+    }
+
+    private fun buildGoalControls() {
+        goalCaloriesField = numberField("Daily calories")
+        goalProteinField = numberField("Daily protein g")
+        goalCarbsField = numberField("Daily carbohydrate g")
+        goalFatField = numberField("Daily fat g")
+    }
+
+    private fun goalsCard(): LinearLayout = NexusUi.card(this).apply {
+        listOf(goalCaloriesField, goalProteinField, goalCarbsField, goalFatField).forEachIndexed { index, field ->
+            if (index > 0) addView(BusTheme.gap(this@FoodLogActivity, 8))
+            addView(field, NexusUi.block())
+        }
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(
+            NexusUi.pillButton(this@FoodLogActivity, "Save goals").apply {
+                setOnClickListener { saveGoals() }
+            },
+            NexusUi.block(),
+        )
+    }
+
+    private fun buildHealthControls() {
+        healthStatus = NexusUi.cardBody(this, "Checking Health Connect…")
+        healthSwitch = NexusUi.switch(this).apply {
+            isChecked = preferences.getBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false)
+            setOnCheckedChangeListener { _, checked ->
+                if (!updatingHealthSwitch) setHealthSyncEnabled(checked)
+            }
+        }
+    }
+
+    private fun healthCard(): LinearLayout = NexusUi.card(this).apply {
+        addView(NexusUi.switchRow(this@FoodLogActivity, "Write nutrition", "Optional; Food Log never reads Health Connect", healthSwitch))
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(healthStatus)
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(
+            NexusUi.outlinePillButton(this@FoodLogActivity, "Sync today now").apply {
+                setOnClickListener { syncTodayToHealthConnect() }
+            },
+            NexusUi.block(),
+        )
+    }
+
+    private fun buildReminderControls() {
+        reminderLabelField = textField("Reminder label")
+        reminderMinutesField = numberField("Minutes from now").apply { setText("60") }
+        reminderKindButton = NexusUi.outlinePillButton(this, "Meal").apply {
+            setOnClickListener {
+                reminderKind = if (reminderKind == FoodLogReminderKind.MEAL) {
+                    FoodLogReminderKind.HYDRATION
+                } else {
+                    FoodLogReminderKind.MEAL
+                }
+                text = if (reminderKind == FoodLogReminderKind.MEAL) "MEAL" else "HYDRATION"
+            }
+        }
+    }
+
+    private fun remindersCard(): LinearLayout = NexusUi.card(this).apply {
+        addView(
+            NexusUi.cardBody(
+                this@FoodLogActivity,
+                "Only reminders you explicitly create here can wake Food Log.",
+            ),
+        )
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(reminderLabelField, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(reminderMinutesField, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(reminderKindButton, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(
+            NexusUi.pillButton(this@FoodLogActivity, "Schedule reminder").apply {
+                setOnClickListener { scheduleReminder() }
+            },
+            NexusUi.block(),
+        )
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(
+            NexusUi.textButton(this@FoodLogActivity, "Exact-alarm settings").apply {
+                setOnClickListener { openExactAlarmSettings() }
+            },
+            NexusUi.block(),
+        )
+    }
+
+    private fun backupCard(): LinearLayout = NexusUi.card(this).apply {
+        addView(
+            NexusUi.cardBody(
+                this@FoodLogActivity,
+                "Export a versioned JSON copy of your journal or merge one back by stable entry ID.",
+            ),
+        )
+        addView(BusTheme.gap(this@FoodLogActivity, 10))
+        addView(
+            NexusUi.outlinePillButton(this@FoodLogActivity, "Export journal").apply {
+                setOnClickListener { chooseExportDestination() }
+            },
+            NexusUi.block(),
+        )
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(
+            NexusUi.outlinePillButton(this@FoodLogActivity, "Import journal").apply {
+                setOnClickListener { chooseImportSource() }
+            },
+            NexusUi.block(),
+        )
     }
 
     private fun addFromBarcode() {
         val barcode = normalizeBarcode(barcodeField.text.toString())
-        val quantity = quantityField.text.toString().replace(',', '.').toDoubleOrNull()
+        val quantity = quantityField.numberOrNull()
         when {
-            barcode == null -> showLookupStatus("Enter a 4–14 digit barcode.")
+            barcode == null -> report("Enter a 4–14 digit barcode.")
             quantity == null || quantity !in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS ->
-                showLookupStatus("Quantity must be between 1 and 5,000 g.")
+                report("Quantity must be between 1 and 5,000 g.")
             else -> {
                 addButton.isEnabled = false
-                showLookupStatus("Looking up product…")
+                missingBarcode = null
+                contributionButton.visibility = View.GONE
+                report("Looking up product…")
                 worker.execute {
-                    val product = store.product(barcode) ?: factsClient.product(barcode)?.also(store::upsertProduct)
-                    if (product == null) {
-                        post { finishLookup("No product found for this barcode.") }
-                        return@execute
+                    val result = runCatching {
+                        store.product(barcode) ?: factsClient.product(barcode)?.also(store::upsertProduct)
                     }
-                    store.addEntry(product, quantity)
                     post {
-                        barcodeField.text?.clear()
-                        finishLookup("Added ${product.name}.")
-                        refreshDay()
+                        addButton.isEnabled = true
+                        result.fold(
+                            onSuccess = { product ->
+                                if (product == null) {
+                                    missingBarcode = barcode
+                                    contributionButton.visibility = View.VISIBLE
+                                    report("Product not found. You can add it to Open Food Facts.")
+                                } else {
+                                    addProduct(product, quantity, selectedMeal, FoodEntrySource.SEARCHED)
+                                    barcodeField.text?.clear()
+                                }
+                            },
+                            onFailure = { report("Lookup failed. Check the phone network connection.") },
+                        )
                     }
                 }
             }
         }
     }
 
-    private fun refreshDay() {
+    private fun addProduct(
+        product: FoodProduct,
+        quantityGrams: Double,
+        mealType: MealType,
+        source: FoodEntrySource,
+        recipeId: String? = null,
+    ) {
+        worker.execute {
+            val id = store.addEntry(
+                product = product,
+                quantityGrams = quantityGrams,
+                consumedAtMillis = System.currentTimeMillis(),
+                mealType = mealType,
+                source = source,
+                recipeId = recipeId,
+            )
+            val entry = store.entry(id)
+            post {
+                report("Added ${product.name} to ${mealType.displayName.lowercase()}.")
+                refreshAll()
+                entry?.let(::syncEntryIfEnabled)
+            }
+        }
+    }
+
+    private fun saveCustomFood() {
+        val name = customNameField.text.toString().trim()
+        if (name.isBlank()) return report("Enter a custom food name.")
+        val core = listOf(customCaloriesField, customProteinField, customCarbsField, customFatField)
+            .map { it.numberOrNull() }
+        val saturatedFat = customSaturatedFatField.numberOrNull()
+        val sodium = customSodiumField.numberOrNull()
+        val potassium = customPotassiumField.numberOrNull()
+        val calcium = customCalciumField.numberOrNull()
+        val iron = customIronField.numberOrNull()
+        val caffeine = customCaffeineField.numberOrNull()
+        val cholesterol = customCholesterolField.numberOrNull()
+        if (core.all { it == null }) return report("Add at least one calorie or macro value.")
+        if ((core + listOf(saturatedFat, sodium, potassium, calcium, iron, caffeine, cholesterol))
+            .any { it != null && (it < 0.0 || it > 100_000.0) }
+        ) {
+            return report("Nutrition values must be between 0 and 100,000.")
+        }
+        worker.execute {
+            val product = store.createCustomFood(
+                name = name,
+                nutrients = NutrientsPer100g(
+                    caloriesKcal = core[0],
+                    proteinGrams = core[1],
+                    carbohydrateGrams = core[2],
+                    fatGrams = core[3],
+                    sugarsGrams = null,
+                    fiberGrams = null,
+                    saltGrams = null,
+                    saturatedFatGrams = saturatedFat,
+                    sodiumMilligrams = sodium,
+                    cholesterolMilligrams = cholesterol,
+                    potassiumMilligrams = potassium,
+                    calciumMilligrams = calcium,
+                    ironMilligrams = iron,
+                    caffeineMilligrams = caffeine,
+                ),
+            )
+            store.setFavorite(product.barcode, true)
+            post {
+                customNameField.text?.clear()
+                report("Saved ${product.name} and added it to favorites.")
+                refreshAll()
+            }
+        }
+    }
+
+    private fun saveRecipe() {
+        val name = recipeNameField.text.toString().trim()
+        val servings = recipeServingsField.numberOrNull()
+        val tokens = recipeIngredientsField.text.toString()
+            .split(';')
+            .map(String::trim)
+            .filter(String::isNotBlank)
+        if (name.isBlank()) return report("Enter a recipe name.")
+        if (servings == null || servings !in 0.25..100.0) return report("Servings must be between 0.25 and 100.")
+        if (tokens.isEmpty() || tokens.size > MAX_RECIPE_INGREDIENTS) return report("Add 1–64 recipe ingredients.")
+        worker.execute {
+            val result = runCatching {
+                val ingredients = tokens.map { token ->
+                    val separator = token.lastIndexOf(':')
+                    require(separator > 0) { "Use product-id:grams for each ingredient." }
+                    val id = token.substring(0, separator).trim()
+                    val grams = token.substring(separator + 1).trim().replace(',', '.').toDoubleOrNull()
+                    require(grams != null && grams in MIN_QUANTITY_GRAMS..MAX_RECIPE_INGREDIENT_GRAMS) {
+                        "Each ingredient must be between 1 and 20,000 g."
+                    }
+                    val product = store.product(id) ?: error("Unknown product ID: $id")
+                    RecipeIngredient(product, grams)
+                }
+                val recipe = FoodRecipe(
+                    uuid = UUID.randomUUID().toString(),
+                    name = name,
+                    servings = servings,
+                    ingredients = ingredients,
+                    createdAtMillis = System.currentTimeMillis(),
+                )
+                store.saveRecipe(recipe)
+                recipe
+            }
+            post {
+                result.fold(
+                    onSuccess = { recipe ->
+                        recipeNameField.text?.clear()
+                        recipeIngredientsField.text?.clear()
+                        report("Saved recipe ${recipe.name}.")
+                        refreshAll()
+                    },
+                    onFailure = { report(it.message ?: "Recipe could not be saved.") },
+                )
+            }
+        }
+    }
+
+    private fun saveGoals() {
+        val result = runCatching {
+            NutritionGoals(
+                caloriesKcal = goalCaloriesField.numberOrNull(),
+                proteinGrams = goalProteinField.numberOrNull(),
+                carbohydrateGrams = goalCarbsField.numberOrNull(),
+                fatGrams = goalFatField.numberOrNull(),
+            )
+        }
+        result.fold(
+            onSuccess = { goals ->
+                worker.execute {
+                    store.saveGoals(goals)
+                    post {
+                        report("Daily goals saved.")
+                        refreshAll()
+                    }
+                }
+            },
+            onFailure = { report("Goals must be positive and within supported limits.") },
+        )
+    }
+
+    private fun cycleMeal() {
+        val values = listOf(MealType.BREAKFAST, MealType.LUNCH, MealType.DINNER, MealType.SNACK)
+        selectedMeal = values[(values.indexOf(selectedMeal).coerceAtLeast(0) + 1) % values.size]
+        mealButton.text = selectedMeal.displayName.uppercase()
+    }
+
+    private fun cycleEntryMeal(entry: FoodEntry) {
+        val values = listOf(MealType.BREAKFAST, MealType.LUNCH, MealType.DINNER, MealType.SNACK)
+        val next = values[(values.indexOf(entry.mealType).coerceAtLeast(0) + 1) % values.size]
+        worker.execute {
+            val updated = store.updateEntryMeal(entry.uuid, next)
+            val updatedEntry = if (updated) store.entry(entry.id) else null
+            post {
+                report(if (updated) "Moved entry to ${next.displayName.lowercase()}." else "Entry no longer exists.")
+                updatedEntry?.let(::syncEntryIfEnabled)
+                refreshAll()
+            }
+        }
+    }
+
+    private fun deleteEntry(entry: FoodEntry) {
+        scope.launch {
+            val deleted = withContext(Dispatchers.IO) {
+                if (entry.uuid.isNotBlank()) store.deleteEntry(entry.uuid) else store.deleteEntry(entry.id)
+            }
+            val healthResult = if (deleted && preferences.getBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false)) {
+                healthBridge.deleteEntry(entry, userOptedIn = true)
+            } else {
+                null
+            }
+            if (healthResult == FoodLogHealthConnectSyncResult.PermissionRequired) {
+                preferences.edit().putBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false).apply()
+                refreshHealthState()
+            }
+            val message = when {
+                !deleted -> "Entry was already removed."
+                healthResult is FoodLogHealthConnectSyncResult.Failed -> "Deleted locally; Health Connect removal failed."
+                healthResult == FoodLogHealthConnectSyncResult.PermissionRequired -> "Deleted locally; Health Connect permission was revoked."
+                else -> "Deleted exactly ${entry.product.name}."
+            }
+            report(message)
+            refreshAll()
+        }
+    }
+
+    private fun toggleFavorite(product: FoodProduct, favorite: Boolean) {
+        worker.execute {
+            store.setFavorite(product.barcode, !favorite)
+            post {
+                report(if (favorite) "Removed from favorites." else "Added to favorites.")
+                refreshAll()
+            }
+        }
+    }
+
+    private fun refreshAll() {
         worker.execute {
             val entries = store.entriesForDay()
-            val totals = aggregateNutrition(entries)
+            val goals = store.goals()
+            val favorites = store.favoriteProducts()
+            val recipes = store.recipes()
+            val week = store.dailySummariesForWeek()
+            val products = store.allProducts()
+            val reminders = runCatching { FoodLogReminderStore(applicationContext).all() }
             post {
-                summary.text = buildString {
-                    append("${totals.entryCount} ${if (totals.entryCount == 1) "entry" else "entries"} today\n")
-                    append("${totals.caloriesKcal.display("kcal")} · ")
-                    append("Protein ${totals.proteinGrams.display("g")} · ")
-                    append("Carbs ${totals.carbohydrateGrams.display("g")} · ")
-                    append("Fat ${totals.fatGrams.display("g")}")
-                }
-                renderEntries(entries)
+                renderSummary(entries, goals)
+                renderEntries(entries, favorites.map(FoodProduct::barcode).toSet())
+                renderFavorites(favorites)
+                renderRecipes(recipes)
+                renderWeek(week)
+                renderProductCatalog(products)
+                reminders.fold(
+                    onSuccess = ::renderReminders,
+                    onFailure = {
+                        remindersList.removeAllViews()
+                        remindersList.emptyCard("Reminder storage could not be read; existing data was preserved.")
+                        report("Reminder storage needs recovery or a valid archive import.")
+                    },
+                )
+                renderGoalFields(goals)
             }
         }
     }
 
-    private fun renderEntries(entries: List<FoodEntry>) {
-        entriesList.removeAllViews()
-        if (entries.isEmpty()) {
-            entriesList.addView(NexusUi.cardBody(this, "No food logged today."), NexusUi.block())
-            return
-        }
-        entries.forEachIndexed { index, entry ->
-            if (index > 0) entriesList.addView(BusTheme.gap(this, 8))
-            entriesList.addView(entryCard(entry), NexusUi.block())
+    private fun renderSummary(entries: List<FoodEntry>, goals: NutritionGoals?) {
+        val totals = aggregateNutrition(entries)
+        summary.text = buildString {
+            append("${totals.entryCount} ${if (totals.entryCount == 1) "entry" else "entries"} today\n")
+            append(progress("Energy", totals.caloriesKcal, goals?.caloriesKcal, "kcal"))
+            append("\n${progress("Protein", totals.proteinGrams, goals?.proteinGrams, "g")}")
+            append(" · ${progress("Carbs", totals.carbohydrateGrams, goals?.carbohydrateGrams, "g")}")
+            append(" · ${progress("Fat", totals.fatGrams, goals?.fatGrams, "g")}")
+            append("\nFiber ${aggregateOptional(entries) { it.fiberGrams }.display("g")}")
+            append(" · Sodium ${totals.sodiumMilligrams.display("mg")}")
+            append(" · Iron ${totals.ironMilligrams.display("mg")}")
+            append(" · Calcium ${totals.calciumMilligrams.display("mg")}")
         }
     }
 
-    private fun entryCard(entry: FoodEntry): LinearLayout = NexusUi.card(this).apply {
-        val top = LinearLayout(this@FoodLogActivity).apply {
-            gravity = android.view.Gravity.CENTER_VERTICAL
-            addView(
-                LinearLayout(this@FoodLogActivity).apply {
-                    orientation = LinearLayout.VERTICAL
+    private fun renderEntries(entries: List<FoodEntry>, favoriteCodes: Set<String>) {
+        entriesList.removeAllViews()
+        if (entries.isEmpty()) return entriesList.emptyCard("No food logged today.")
+        entries.forEachIndexed { index, entry ->
+            if (index > 0) entriesList.addView(BusTheme.gap(this, 8))
+            entriesList.addView(
+                NexusUi.card(this).apply {
                     addView(NexusUi.rowTitle(this@FoodLogActivity, entry.product.name))
                     addView(
                         NexusUi.rowSub(
                             this@FoodLogActivity,
-                            listOfNotNull(
-                                formatEntryTime(entry.consumedAtMillis),
-                                entry.product.brand.takeIf(String::isNotBlank),
-                                "${formatNutritionNumber(entry.quantityGrams)} g",
-                            ).joinToString(" · "),
+                            "${formatEntryTime(entry.consumedAtMillis)} · ${entry.mealType.displayName} · ${formatNutritionNumber(entry.quantityGrams)} g",
+                        ),
+                    )
+                    addView(BusTheme.gap(this@FoodLogActivity, 8))
+                    val calories = scaledValue(entry.product.nutrients.caloriesKcal, entry.quantityGrams)
+                    addView(NexusUi.metaLabel(this@FoodLogActivity, "${calories.value("kcal")} · ${entry.product.barcode}"))
+                    addView(BusTheme.gap(this@FoodLogActivity, 8))
+                    addView(
+                        horizontalActions(
+                            NexusUi.textButton(this@FoodLogActivity, entry.mealType.displayName).apply {
+                                setOnClickListener { cycleEntryMeal(entry) }
+                            },
+                            NexusUi.textButton(
+                                this@FoodLogActivity,
+                                if (entry.product.barcode in favoriteCodes) "Unfavorite" else "Favorite",
+                            ).apply {
+                                setOnClickListener {
+                                    toggleFavorite(entry.product, entry.product.barcode in favoriteCodes)
+                                }
+                            },
+                            NexusUi.textButton(this@FoodLogActivity, "Delete", danger = true).apply {
+                                setOnClickListener { deleteEntry(entry) }
+                            },
                         ),
                     )
                 },
-                LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
+                NexusUi.block(),
             )
-            addView(NexusUi.textButton(this@FoodLogActivity, "Delete", danger = true).apply {
-                setOnClickListener { deleteEntry(entry.id) }
-            })
         }
-        addView(top, NexusUi.block())
-        addView(BusTheme.gap(this@FoodLogActivity, 8))
-        addView(
-            NexusUi.metaLabel(
-                this@FoodLogActivity,
-                "${scaledValue(entry.product.nutrients.caloriesKcal, entry.quantityGrams).displayPer100g("kcal")} · " +
-                    "P ${scaledValue(entry.product.nutrients.proteinGrams, entry.quantityGrams).displayPer100g("g")} · " +
-                    "C ${scaledValue(entry.product.nutrients.carbohydrateGrams, entry.quantityGrams).displayPer100g("g")} · " +
-                    "F ${scaledValue(entry.product.nutrients.fatGrams, entry.quantityGrams).displayPer100g("g")}",
-            ),
-        )
     }
 
-    private fun deleteEntry(id: Long) {
+    private fun renderFavorites(products: List<FoodProduct>) {
+        favoritesList.removeAllViews()
+        if (products.isEmpty()) return favoritesList.emptyCard("Favorite an entry or create a custom food.")
+        products.forEachIndexed { index, product ->
+            if (index > 0) favoritesList.addView(BusTheme.gap(this, 8))
+            favoritesList.addView(actionRow(product.name, product.brand.ifBlank { product.barcode }, "Add") {
+                val amount = product.servingGrams?.takeIf { it in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS } ?: 100.0
+                addProduct(product, amount, selectedMeal, sourceFor(product))
+            }, NexusUi.block())
+        }
+    }
+
+    private fun renderRecipes(recipes: List<FoodRecipe>) {
+        recipesList.removeAllViews()
+        if (recipes.isEmpty()) return recipesList.emptyCard("No saved recipes.")
+        recipes.forEachIndexed { index, recipe ->
+            if (index > 0) recipesList.addView(BusTheme.gap(this, 8))
+            val product = recipe.asProduct()
+            recipesList.addView(
+                actionRow(
+                    recipe.name,
+                    "${recipe.ingredients.size} ingredients · ${formatNutritionNumber(recipe.servings)} servings",
+                    "Log serving",
+                ) {
+                    addProduct(
+                        product,
+                        product.servingGrams ?: 100.0,
+                        selectedMeal,
+                        FoodEntrySource.RECIPE,
+                        recipe.uuid,
+                    )
+                },
+                NexusUi.block(),
+            )
+        }
+    }
+
+    private fun renderWeek(days: List<Pair<java.time.LocalDate, DailyNutritionTotals>>) {
+        weeklyList.removeAllViews()
+        val formatter = DateTimeFormatter.ofPattern("EEE d")
+        days.forEachIndexed { index, (date, totals) ->
+            if (index > 0) weeklyList.addView(BusTheme.gap(this, 8))
+            weeklyList.addView(
+                NexusUi.card(this).apply {
+                    addView(NexusUi.rowTitle(this@FoodLogActivity, date.format(formatter)))
+                    addView(
+                        NexusUi.rowSub(
+                            this@FoodLogActivity,
+                            "${totals.caloriesKcal.display("kcal")} · P ${totals.proteinGrams.display("g")} · ${totals.entryCount} entries",
+                        ),
+                    )
+                },
+                NexusUi.block(),
+            )
+        }
+    }
+
+    private fun renderProductCatalog(products: List<FoodProduct>) {
+        productCatalog.removeAllViews()
+        if (products.isEmpty()) return productCatalog.emptyCard("No products stored yet.")
+        products.take(MAX_CATALOG_PRODUCTS).forEachIndexed { index, product ->
+            if (index > 0) productCatalog.addView(BusTheme.gap(this, 6))
+            productCatalog.addView(
+                NexusUi.card(this).apply {
+                    addView(NexusUi.rowTitle(this@FoodLogActivity, product.name))
+                    addView(NexusUi.rowSub(this@FoodLogActivity, product.barcode))
+                },
+                NexusUi.block(),
+            )
+        }
+        if (products.size > MAX_CATALOG_PRODUCTS) {
+            productCatalog.addView(NexusUi.cardBody(this, "${products.size - MAX_CATALOG_PRODUCTS} more products omitted."))
+        }
+    }
+
+    private fun renderReminders(reminders: List<FoodLogReminder>) {
+        remindersList.removeAllViews()
+        if (reminders.isEmpty()) return remindersList.emptyCard("No scheduled reminders.")
+        reminders.forEachIndexed { index, reminder ->
+            if (index > 0) remindersList.addView(BusTheme.gap(this, 8))
+            remindersList.addView(NexusUi.card(this).apply {
+                addView(NexusUi.rowTitle(this@FoodLogActivity, reminder.label))
+                addView(BusTheme.gap(this@FoodLogActivity, 4))
+                addView(NexusUi.rowSub(
+                    this@FoodLogActivity,
+                    "${reminder.kind.name.lowercase().replaceFirstChar(Char::uppercase)} · ${formatReminderTime(reminder.epochMillis)} · ${if (reminder.enabled) "active" else "paused"}",
+                ))
+                addView(BusTheme.gap(this@FoodLogActivity, 8))
+                addView(horizontalActions(
+                    NexusUi.textButton(this@FoodLogActivity, if (reminder.enabled) "Pause" else "Resume").apply {
+                        setOnClickListener { setReminderEnabled(reminder, !reminder.enabled) }
+                    },
+                    NexusUi.textButton(this@FoodLogActivity, "Cancel", true).apply {
+                        setOnClickListener { cancelReminder(reminder.id) }
+                    },
+                ))
+            }, NexusUi.block())
+        }
+    }
+
+    private fun renderGoalFields(goals: NutritionGoals?) {
+        if (goalCaloriesField.hasFocus() || goalProteinField.hasFocus() || goalCarbsField.hasFocus() || goalFatField.hasFocus()) return
+        goalCaloriesField.setNumber(goals?.caloriesKcal)
+        goalProteinField.setNumber(goals?.proteinGrams)
+        goalCarbsField.setNumber(goals?.carbohydrateGrams)
+        goalFatField.setNumber(goals?.fatGrams)
+    }
+
+    private fun scheduleReminder() {
+        val label = reminderLabelField.text.toString().trim()
+        val minutes = reminderMinutesField.numberOrNull()
+        if (label.isBlank()) return report("Enter a reminder label.")
+        if (minutes == null || minutes !in 1.0..525_600.0) return report("Reminder time must be 1–525,600 minutes.")
+        val kind = reminderKind
         worker.execute {
-            val deleted = store.deleteEntry(id)
+            val result = runCatching {
+                val reminderStore = FoodLogReminderStore(applicationContext)
+                val reminder = reminderStore.create(
+                    kind = kind,
+                    label = label,
+                    epochMillis = System.currentTimeMillis() + (minutes * 60_000.0).toLong(),
+                )
+                try {
+                    foodLogReminderScheduler(applicationContext).schedule(reminder)
+                    reminder
+                } catch (exception: Exception) {
+                    reminderStore.delete(reminder.id)
+                    throw exception
+                }
+            }
             post {
-                showLookupStatus(if (deleted) "Entry deleted." else "Entry was already removed.")
-                refreshDay()
+                if (result.isSuccess) {
+                    reminderLabelField.text?.clear()
+                    maybeRequestNotificationPermission()
+                    report("Reminder scheduled${if (canScheduleExactAlarm()) " exactly" else " with inexact timing"}.")
+                    refreshAll()
+                } else {
+                    report("Reminder could not be scheduled.")
+                }
             }
         }
     }
 
-    private fun finishLookup(message: String) {
-        addButton.isEnabled = true
-        showLookupStatus(message)
+    private fun cancelReminder(id: String) {
+        worker.execute {
+            val result = runCatching {
+                val removed = FoodLogReminderStore(applicationContext).cancel(id)
+                if (removed != null) runCatching { foodLogReminderScheduler(applicationContext).cancel(id) }
+                removed
+            }
+            post {
+                report(result.fold(
+                    onSuccess = { if (it != null) "Cancelled exactly that reminder." else "Reminder no longer exists." },
+                    onFailure = { "Reminder could not be cancelled; existing data was preserved." },
+                ))
+                refreshAll()
+            }
+        }
     }
 
-    private fun showLookupStatus(message: String) {
-        lookupStatus.text = message
-        lookupStatus.visibility = View.VISIBLE
+    private fun setReminderEnabled(reminder: FoodLogReminder, enabled: Boolean) {
+        worker.execute {
+            val reminderStore = FoodLogReminderStore(applicationContext)
+            val scheduler = foodLogReminderScheduler(applicationContext)
+            val updated = reminder.copy(enabled = enabled)
+            val result = runCatching {
+                check(reminderStore.update(updated)) { "Reminder no longer exists" }
+                if (enabled) {
+                    try {
+                        scheduler.reschedule(updated)
+                    } catch (exception: Exception) {
+                        reminderStore.update(reminder)
+                        throw exception
+                    }
+                } else {
+                    runCatching { scheduler.cancel(reminder.id) }
+                }
+            }
+            post {
+                report(
+                    if (result.isSuccess) {
+                        if (enabled) "Reminder resumed." else "Reminder paused."
+                    } else {
+                        "Reminder could not be updated."
+                    },
+                )
+                refreshAll()
+            }
+        }
+    }
+
+    private fun setHealthSyncEnabled(enabled: Boolean) {
+        if (!enabled) {
+            healthConsentGeneration += 1L
+            pendingHealthPermissionGeneration = null
+            preferences.edit().putBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false).apply()
+            healthStatus.text = "Sync is off. Existing Health Connect records are not deleted."
+            return
+        }
+        val requestGeneration = ++healthConsentGeneration
+        scope.launch {
+            when (healthBridge.availability()) {
+                FoodLogHealthConnectAvailability.Available -> {
+                    if (healthBridge.hasWriteNutritionPermission()) {
+                        if (requestGeneration != healthConsentGeneration) return@launch
+                        preferences.edit().putBoolean(FOOD_LOG_HEALTH_SYNC_KEY, true).apply()
+                        report("Health Connect sync enabled.")
+                        refreshHealthState()
+                    } else {
+                        if (requestGeneration != healthConsentGeneration) return@launch
+                        updatingHealthSwitch = true
+                        healthSwitch.isChecked = false
+                        updatingHealthSwitch = false
+                        val intent = healthPermissionContract.createIntent(
+                            this@FoodLogActivity,
+                            setOf(FoodLogHealthConnectBridge.WRITE_NUTRITION_PERMISSION),
+                        )
+                        pendingHealthPermissionGeneration = requestGeneration
+                        @Suppress("DEPRECATION")
+                        startActivityForResult(intent, REQUEST_HEALTH_PERMISSION)
+                    }
+                }
+                FoodLogHealthConnectAvailability.ProviderUpdateRequired -> {
+                    setHealthSwitch(false)
+                    healthStatus.text = "Health Connect needs an update."
+                }
+                FoodLogHealthConnectAvailability.Unavailable -> {
+                    setHealthSwitch(false)
+                    healthStatus.text = "Health Connect is unavailable on this phone."
+                }
+            }
+        }
+    }
+
+    private fun refreshHealthState() {
+        scope.launch {
+            val optedIn = preferences.getBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false)
+            when (healthBridge.availability()) {
+                FoodLogHealthConnectAvailability.Available -> {
+                    val granted = healthBridge.hasWriteNutritionPermission()
+                    if (optedIn && !granted) preferences.edit().putBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false).apply()
+                    setHealthSwitch(optedIn && granted)
+                    healthStatus.text = when {
+                        optedIn && granted -> "Enabled. New entries are written after local save."
+                        granted -> "Permission granted, but sync is off."
+                        else -> "Off. Enable to request write-only nutrition access."
+                    }
+                }
+                FoodLogHealthConnectAvailability.ProviderUpdateRequired -> {
+                    setHealthSwitch(false)
+                    healthStatus.text = "Health Connect needs an update."
+                }
+                FoodLogHealthConnectAvailability.Unavailable -> {
+                    setHealthSwitch(false)
+                    healthStatus.text = "Health Connect is unavailable on this phone."
+                }
+            }
+        }
+    }
+
+    private fun setHealthSwitch(checked: Boolean) {
+        updatingHealthSwitch = true
+        healthSwitch.isChecked = checked
+        updatingHealthSwitch = false
+    }
+
+    private fun syncEntryIfEnabled(entry: FoodEntry) {
+        if (!preferences.getBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false)) return
+        scope.launch {
+            when (val result = healthBridge.syncEntry(entry, userOptedIn = true)) {
+                FoodLogHealthConnectSyncResult.Synced -> Unit
+                FoodLogHealthConnectSyncResult.PermissionRequired -> {
+                    preferences.edit().putBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false).apply()
+                    report("Saved locally; Health Connect permission was revoked.")
+                    refreshHealthState()
+                }
+                is FoodLogHealthConnectSyncResult.Failed -> report("Saved locally; Health Connect sync failed.")
+                else -> Unit
+            }
+        }
+    }
+
+    private fun syncTodayToHealthConnect() {
+        if (!preferences.getBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false)) return report("Enable Health Connect first.")
+        scope.launch {
+            val entries = withContext(Dispatchers.IO) { store.entriesForDay() }
+            var synced = 0
+            var permissionRevoked = false
+            var failed = 0
+            for (entry in entries) {
+                when (healthBridge.syncEntry(entry, userOptedIn = true)) {
+                    FoodLogHealthConnectSyncResult.Synced -> synced += 1
+                    FoodLogHealthConnectSyncResult.PermissionRequired -> {
+                        permissionRevoked = true
+                        preferences.edit().putBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false).apply()
+                        break
+                    }
+                    is FoodLogHealthConnectSyncResult.Failed -> failed += 1
+                    else -> Unit
+                }
+            }
+            if (permissionRevoked) refreshHealthState()
+            report(
+                when {
+                    permissionRevoked -> "Synced $synced entries; Health Connect permission was revoked."
+                    failed > 0 -> "Synced $synced of ${entries.size} entries; $failed failed."
+                    else -> "Synced $synced of ${entries.size} entries to Health Connect."
+                },
+            )
+        }
+    }
+
+    private fun chooseExportDestination() {
+        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "application/json"
+            putExtra(Intent.EXTRA_TITLE, "food-log-backup.json")
+        }
+        @Suppress("DEPRECATION")
+        startActivityForResult(intent, REQUEST_EXPORT)
+    }
+
+    private fun chooseImportSource() {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "application/json"
+        }
+        @Suppress("DEPRECATION")
+        startActivityForResult(intent, REQUEST_IMPORT)
+    }
+
+    private fun writeBackup(uri: Uri) {
+        worker.execute {
+            val result = runCatching {
+                val reminders = FoodLogReminderStore(applicationContext).all()
+                val json = store.exportJson(reminders)
+                contentResolver.openOutputStream(uri, "wt")?.bufferedWriter(Charsets.UTF_8)?.use { it.write(json) }
+                    ?: error("Destination unavailable")
+            }
+            post { report(if (result.isSuccess) "Food Log archive exported." else "Export failed.") }
+        }
+    }
+
+    private fun readBackup(uri: Uri) {
+        worker.execute {
+            val result = runCatching {
+                val json = contentResolver.openInputStream(uri)?.bufferedReader(Charsets.UTF_8)?.use(::readBounded)
+                    ?: error("Source unavailable")
+                val imported = store.importJson(json)
+                val reminders = FoodLogReminderStore(applicationContext).merge(imported.reminders)
+                val scheduler = foodLogReminderScheduler(applicationContext)
+                val scheduleFailures = reminders.count { reminder ->
+                    reminder.enabled && runCatching { scheduler.reschedule(reminder) }.isFailure
+                }
+                imported to scheduleFailures
+            }
+            post {
+                result.fold(
+                    onSuccess = { (imported, scheduleFailures) ->
+                        val warning = if (scheduleFailures == 0) "" else " $scheduleFailures reminders need rescheduling."
+                        report("Imported ${imported.insertedEntries} new entries and ${imported.reminders.size} reminders; stable duplicates were merged.$warning")
+                        refreshAll()
+                    },
+                    onFailure = { report("Import rejected: ${it.message ?: "invalid backup"}") },
+                )
+            }
+        }
+    }
+
+    private fun openFoodFactsContribution(barcode: String) {
+        val uri = Uri.parse("https://world.openfoodfacts.org/cgi/product.pl")
+            .buildUpon()
+            .appendQueryParameter("type", "edit")
+            .appendQueryParameter("code", barcode)
+            .build()
+        startActivity(Intent(Intent.ACTION_VIEW, uri))
+    }
+
+    private fun readBounded(reader: java.io.Reader): String {
+        val output = StringBuilder()
+        val buffer = CharArray(8_192)
+        while (true) {
+            val count = reader.read(buffer)
+            if (count < 0) break
+            require(output.length + count <= MAX_BACKUP_CHARS) { "Backup is too large" }
+            output.append(buffer, 0, count)
+        }
+        return output.toString()
+    }
+
+    private fun openExactAlarmSettings() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return report("Exact alarms are already available.")
+        runCatching {
+            startActivity(
+                Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+                    data = Uri.parse("package:$packageName")
+                },
+            )
+        }.onFailure { report("Exact-alarm settings are unavailable on this phone.") }
+    }
+
+    private fun maybeRequestNotificationPermission() {
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS), REQUEST_NOTIFICATIONS)
+        }
+    }
+
+    private fun canScheduleExactAlarm(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+            getSystemService(android.app.AlarmManager::class.java).canScheduleExactAlarms()
+
+    private fun actionRow(
+        title: String,
+        subtitle: String,
+        action: String,
+        danger: Boolean = false,
+        onClick: () -> Unit,
+    ): LinearLayout = NexusUi.pressableCard(this).apply {
+        addView(
+            LinearLayout(this@FoodLogActivity).apply {
+                orientation = LinearLayout.VERTICAL
+                addView(NexusUi.rowTitle(this@FoodLogActivity, title))
+                addView(BusTheme.gap(this@FoodLogActivity, 4))
+                addView(NexusUi.rowSub(this@FoodLogActivity, subtitle))
+            },
+            LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
+        )
+        addView(NexusUi.textButton(this@FoodLogActivity, action, danger).apply { setOnClickListener { onClick() } })
+    }
+
+    private fun horizontalActions(vararg buttons: Button): LinearLayout = LinearLayout(this).apply {
+        orientation = LinearLayout.HORIZONTAL
+        buttons.forEach { button -> addView(button, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)) }
+    }
+
+    private fun verticalList() = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+
+    private fun LinearLayout.emptyCard(message: String) {
+        addView(NexusUi.cardBody(this@FoodLogActivity, message), NexusUi.block())
+    }
+
+    private fun textField(hint: String): EditText = NexusUi.field(this, hint)
+
+    private fun numberField(hint: String): EditText = NexusUi.field(this, hint).apply {
+        inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
+    }
+
+    private fun EditText.numberOrNull(): Double? = text.toString().trim().replace(',', '.').toDoubleOrNull()
+
+    private fun EditText.setNumber(value: Double?) {
+        setText(value?.let(::formatNutritionNumber).orEmpty())
+    }
+
+    private fun progress(label: String, total: NutritionTotal, goal: Double?, unit: String): String {
+        val value = total.display(unit)
+        val percent = goal?.takeIf { it > 0.0 }?.let { total.knownValue / it * 100.0 }
+        return if (percent == null) "$label $value" else "$label $value / ${formatNutritionNumber(goal)} $unit (${formatNutritionNumber(percent)}%)"
+    }
+
+    private fun aggregateOptional(entries: List<FoodEntry>, selector: (NutrientsPer100g) -> Double?): NutritionTotal {
+        var total = 0.0
+        var complete = true
+        entries.forEach { entry ->
+            val value = selector(entry.product.nutrients)
+            if (value == null) complete = false else total += value * entry.quantityGrams / 100.0
+        }
+        return NutritionTotal(total, complete)
+    }
+
+    private fun sourceFor(product: FoodProduct): FoodEntrySource = when {
+        product.barcode.startsWith("custom-") -> FoodEntrySource.CUSTOM
+        product.barcode.startsWith("recipe-") -> FoodEntrySource.RECIPE
+        else -> FoodEntrySource.SEARCHED
+    }
+
+    private fun Double?.value(unit: String): String = this?.let { "${formatNutritionNumber(it)} $unit" } ?: "unknown"
+
+    private fun formatEntryTime(millis: Long): String =
+        ENTRY_TIME_FORMAT.format(Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()))
+
+    private fun formatReminderTime(millis: Long): String =
+        REMINDER_TIME_FORMAT.format(Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()))
+
+    private fun report(message: String) {
+        status.text = message
+        status.visibility = View.VISIBLE
     }
 
     private fun post(block: () -> Unit) {
-        main.post { if (!destroyed) block() }
+        runOnUiThread { if (!destroyed) block() }
     }
-
-    private fun formatEntryTime(millis: Long): String =
-        ENTRY_TIME_FORMAT.format(Instant.ofEpochMilli(millis).atZone(java.time.ZoneId.systemDefault()))
 
     private fun uninstallRow() = NexusUi.uninstallCard(this, "Food Log") {
         startActivity(Intent(Intent.ACTION_DELETE, Uri.parse("package:$packageName")))
@@ -263,6 +1283,13 @@ class FoodLogActivity : Activity() {
 
     private companion object {
         const val DEFAULT_QUANTITY_GRAMS = "100"
+        const val REQUEST_HEALTH_PERMISSION = 301
+        const val REQUEST_EXPORT = 302
+        const val REQUEST_IMPORT = 303
+        const val REQUEST_NOTIFICATIONS = 304
+        const val MAX_CATALOG_PRODUCTS = 50
+        const val MAX_BACKUP_CHARS = 12_000_000
         val ENTRY_TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+        val REMINDER_TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
     }
 }

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogActivity.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogActivity.kt
@@ -1,0 +1,268 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.text.InputType
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.anezium.rokidbus.client.ui.BusTheme
+import com.anezium.rokidbus.client.ui.NexusPluginIcons
+import com.anezium.rokidbus.client.ui.NexusUi
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/** Phone-side daily journal and manual barcode fallback for Food Log. */
+class FoodLogActivity : Activity() {
+    private lateinit var store: FoodLogStore
+    private val factsClient = FoodFactsClient()
+    private val worker: ExecutorService = Executors.newSingleThreadExecutor()
+    private val main = Handler(Looper.getMainLooper())
+
+    private lateinit var barcodeField: EditText
+    private lateinit var quantityField: EditText
+    private lateinit var addButton: View
+    private lateinit var lookupStatus: TextView
+    private lateinit var summary: TextView
+    private lateinit var entriesList: LinearLayout
+    private var destroyed = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        store = FoodLogStore(applicationContext)
+        buildUi()
+        refreshDay()
+    }
+
+    override fun onDestroy() {
+        destroyed = true
+        main.removeCallbacksAndMessages(null)
+        worker.shutdownNow()
+        if (::store.isInitialized) store.close()
+        super.onDestroy()
+    }
+
+    private fun buildUi() {
+        window.statusBarColor = NexusUi.BG
+        window.navigationBarColor = NexusUi.BG
+        barcodeField = NexusUi.field(this, "Barcode").apply {
+            inputType = InputType.TYPE_CLASS_NUMBER
+            imeOptions = EditorInfo.IME_ACTION_NEXT
+        }
+        quantityField = NexusUi.field(this, "Quantity in grams").apply {
+            inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
+            imeOptions = EditorInfo.IME_ACTION_DONE
+            setText(DEFAULT_QUANTITY_GRAMS)
+            setOnEditorActionListener { _, actionId, _ ->
+                if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    addFromBarcode()
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+        lookupStatus = NexusUi.statusLine(this).apply { visibility = View.GONE }
+        summary = NexusUi.cardBody(this, "Loading today’s journal…")
+        entriesList = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        addButton = NexusUi.pillButton(this, "Look up and add").apply {
+            setOnClickListener { addFromBarcode() }
+        }
+
+        val content = NexusUi.contentColumn(this).apply {
+            addView(
+                NexusUi.cardBody(
+                    this@FoodLogActivity,
+                    "Log packaged food by barcode. Product data comes from Open Food Facts and can be incomplete.",
+                ),
+                NexusUi.block(),
+            )
+            addView(BusTheme.gap(this@FoodLogActivity, 18))
+            addView(NexusUi.sectionRow(this@FoodLogActivity, "Today"), NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 10))
+            addView(NexusUi.card(this@FoodLogActivity).apply { addView(summary) }, NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 22))
+            addView(NexusUi.sectionRow(this@FoodLogActivity, "Add food"), NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 10))
+            addView(barcodeField, NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 8))
+            addView(quantityField, NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 10))
+            addView(addButton, NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 8))
+            addView(lookupStatus, NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 22))
+            addView(NexusUi.sectionRow(this@FoodLogActivity, "Entries"), NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 10))
+            addView(entriesList, NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 24))
+            addView(NexusUi.sectionRow(this@FoodLogActivity, "Data"), NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 10))
+            addView(
+                NexusUi.cardBody(
+                    this@FoodLogActivity,
+                    "Open Food Facts is a collaborative database. Check the label when nutrition data matters.",
+                ),
+                NexusUi.block(),
+            )
+            addView(BusTheme.gap(this@FoodLogActivity, 24))
+            addView(NexusUi.sectionRow(this@FoodLogActivity, "Plugin"), NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogActivity, 10))
+            addView(uninstallRow(), NexusUi.block())
+        }
+        setContentView(NexusUi.fixedRoot(this).apply {
+            addView(
+                NexusUi.pluginHeader(
+                    this@FoodLogActivity,
+                    NexusPluginIcons.drawableFor("heart"),
+                    "Food Log",
+                    "Daily nutrition journal · v0.1",
+                ),
+                NexusUi.block(),
+            )
+            addView(
+                NexusUi.screen(this@FoodLogActivity, content),
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f),
+            )
+        })
+    }
+
+    private fun addFromBarcode() {
+        val barcode = normalizeBarcode(barcodeField.text.toString())
+        val quantity = quantityField.text.toString().replace(',', '.').toDoubleOrNull()
+        when {
+            barcode == null -> showLookupStatus("Enter a 4–14 digit barcode.")
+            quantity == null || quantity !in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS ->
+                showLookupStatus("Quantity must be between 1 and 5,000 g.")
+            else -> {
+                addButton.isEnabled = false
+                showLookupStatus("Looking up product…")
+                worker.execute {
+                    val product = store.product(barcode) ?: factsClient.product(barcode)?.also(store::upsertProduct)
+                    if (product == null) {
+                        post { finishLookup("No product found for this barcode.") }
+                        return@execute
+                    }
+                    store.addEntry(product, quantity)
+                    post {
+                        barcodeField.text?.clear()
+                        finishLookup("Added ${product.name}.")
+                        refreshDay()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun refreshDay() {
+        worker.execute {
+            val entries = store.entriesForDay()
+            val totals = aggregateNutrition(entries)
+            post {
+                summary.text = buildString {
+                    append("${totals.entryCount} ${if (totals.entryCount == 1) "entry" else "entries"} today\n")
+                    append("${totals.caloriesKcal.display("kcal")} · ")
+                    append("Protein ${totals.proteinGrams.display("g")} · ")
+                    append("Carbs ${totals.carbohydrateGrams.display("g")} · ")
+                    append("Fat ${totals.fatGrams.display("g")}")
+                }
+                renderEntries(entries)
+            }
+        }
+    }
+
+    private fun renderEntries(entries: List<FoodEntry>) {
+        entriesList.removeAllViews()
+        if (entries.isEmpty()) {
+            entriesList.addView(NexusUi.cardBody(this, "No food logged today."), NexusUi.block())
+            return
+        }
+        entries.forEachIndexed { index, entry ->
+            if (index > 0) entriesList.addView(BusTheme.gap(this, 8))
+            entriesList.addView(entryCard(entry), NexusUi.block())
+        }
+    }
+
+    private fun entryCard(entry: FoodEntry): LinearLayout = NexusUi.card(this).apply {
+        val top = LinearLayout(this@FoodLogActivity).apply {
+            gravity = android.view.Gravity.CENTER_VERTICAL
+            addView(
+                LinearLayout(this@FoodLogActivity).apply {
+                    orientation = LinearLayout.VERTICAL
+                    addView(NexusUi.rowTitle(this@FoodLogActivity, entry.product.name))
+                    addView(
+                        NexusUi.rowSub(
+                            this@FoodLogActivity,
+                            listOfNotNull(
+                                formatEntryTime(entry.consumedAtMillis),
+                                entry.product.brand.takeIf(String::isNotBlank),
+                                "${formatNutritionNumber(entry.quantityGrams)} g",
+                            ).joinToString(" · "),
+                        ),
+                    )
+                },
+                LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
+            )
+            addView(NexusUi.textButton(this@FoodLogActivity, "Delete", danger = true).apply {
+                setOnClickListener { deleteEntry(entry.id) }
+            })
+        }
+        addView(top, NexusUi.block())
+        addView(BusTheme.gap(this@FoodLogActivity, 8))
+        addView(
+            NexusUi.metaLabel(
+                this@FoodLogActivity,
+                "${scaledValue(entry.product.nutrients.caloriesKcal, entry.quantityGrams).displayPer100g("kcal")} · " +
+                    "P ${scaledValue(entry.product.nutrients.proteinGrams, entry.quantityGrams).displayPer100g("g")} · " +
+                    "C ${scaledValue(entry.product.nutrients.carbohydrateGrams, entry.quantityGrams).displayPer100g("g")} · " +
+                    "F ${scaledValue(entry.product.nutrients.fatGrams, entry.quantityGrams).displayPer100g("g")}",
+            ),
+        )
+    }
+
+    private fun deleteEntry(id: Long) {
+        worker.execute {
+            val deleted = store.deleteEntry(id)
+            post {
+                showLookupStatus(if (deleted) "Entry deleted." else "Entry was already removed.")
+                refreshDay()
+            }
+        }
+    }
+
+    private fun finishLookup(message: String) {
+        addButton.isEnabled = true
+        showLookupStatus(message)
+    }
+
+    private fun showLookupStatus(message: String) {
+        lookupStatus.text = message
+        lookupStatus.visibility = View.VISIBLE
+    }
+
+    private fun post(block: () -> Unit) {
+        main.post { if (!destroyed) block() }
+    }
+
+    private fun formatEntryTime(millis: Long): String =
+        ENTRY_TIME_FORMAT.format(Instant.ofEpochMilli(millis).atZone(java.time.ZoneId.systemDefault()))
+
+    private fun uninstallRow() = NexusUi.uninstallCard(this, "Food Log") {
+        startActivity(Intent(Intent.ACTION_DELETE, Uri.parse("package:$packageName")))
+    }
+
+    private companion object {
+        const val DEFAULT_QUANTITY_GRAMS = "100"
+        val ENTRY_TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+    }
+}

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogBackup.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogBackup.kt
@@ -1,0 +1,47 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** Bounded, versioned local backup codec. Parsing never accepts partial data. */
+internal object FoodLogBackup {
+    const val SCHEMA_VERSION = 2
+    private const val MAX_ENTRIES = 20_000
+    private const val MAX_TEXT = 300
+
+    fun encode(entries: List<FoodEntry>): String = JSONObject().apply {
+        put("schemaVersion", SCHEMA_VERSION)
+        put("entries", JSONArray().apply { entries.forEach { put(it.toJson()) } })
+    }.toString()
+
+    fun decode(text: String): List<FoodEntry> {
+        require(text.length <= 12_000_000) { "Backup is too large" }
+        val root = JSONObject(text)
+        require(root.optInt("schemaVersion", -1) == SCHEMA_VERSION) { "Unsupported backup schema" }
+        val array = root.optJSONArray("entries") ?: throw IllegalArgumentException("Missing entries")
+        require(array.length() <= MAX_ENTRIES) { "Too many entries" }
+        val seen = HashSet<String>()
+        return List(array.length()) { index -> entryFromJson(array.getJSONObject(index)).also { require(seen.add(it.uuid)) { "Duplicate entry UUID" } } }
+    }
+
+    private fun FoodEntry.toJson() = JSONObject().apply {
+        put("uuid", uuid); put("consumedAtMillis", consumedAtMillis); put("quantityGrams", quantityGrams)
+        put("mealType", mealType.name); put("source", source.name); put("recipeId", recipeId); put("product", product.toJson())
+    }
+    private fun FoodProduct.toJson() = JSONObject().apply {
+        put("barcode", barcode); put("name", name); put("brand", brand); put("fetchedAtMillis", fetchedAtMillis)
+        put("nutrients", JSONObject().apply { nutrientsValues().forEach { put(it.first, it.second) } })
+    }
+    private fun FoodProduct.nutrientsValues() = listOf("calories" to nutrients.caloriesKcal,"protein" to nutrients.proteinGrams,"carbohydrate" to nutrients.carbohydrateGrams,"fat" to nutrients.fatGrams,"sugars" to nutrients.sugarsGrams,"fiber" to nutrients.fiberGrams,"salt" to nutrients.saltGrams,"saturatedFat" to nutrients.saturatedFatGrams,"sodium" to nutrients.sodiumMilligrams,"cholesterol" to nutrients.cholesterolMilligrams,"potassium" to nutrients.potassiumMilligrams,"calcium" to nutrients.calciumMilligrams,"iron" to nutrients.ironMilligrams,"caffeine" to nutrients.caffeineMilligrams)
+    private fun entryFromJson(o: JSONObject): FoodEntry {
+        val uuid = text(o,"uuid",64); require(uuid.matches(Regex("[A-Za-z0-9-]{1,64}")))
+        val quantity=o.optDouble("quantityGrams",Double.NaN); require(quantity in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS)
+        val consumed=o.optLong("consumedAtMillis",Long.MIN_VALUE); require(consumed > 0)
+        val p=o.optJSONObject("product") ?: throw IllegalArgumentException("Missing product")
+        val barcode = text(p,"barcode",70); require(productId(barcode) != null)
+        return FoodEntry(0,consumed,quantity,FoodProduct(barcode,text(p,"name",MAX_TEXT),text(p,"brand",MAX_TEXT),null,null,null,null,nutrients(p.optJSONObject("nutrients") ?: throw IllegalArgumentException("Missing nutrients")),p.optLong("fetchedAtMillis",0)),uuid,enum(o,"mealType",MealType.UNKNOWN),enum(o,"source",FoodEntrySource.UNKNOWN),o.optString("recipeId").takeIf { it.isNotBlank() && it.length <= 64 })
+    }
+    private fun nutrients(o: JSONObject): NutrientsPer100g { fun n(k:String)=if(!o.has(k)||o.isNull(k))null else o.optDouble(k,Double.NaN).takeIf { it.isFinite() && it>=0 }; return NutrientsPer100g(n("calories"),n("protein"),n("carbohydrate"),n("fat"),n("sugars"),n("fiber"),n("salt"),n("saturatedFat"),n("sodium"),n("cholesterol"),n("potassium"),n("calcium"),n("iron"),n("caffeine")) }
+    private fun text(o:JSONObject,k:String,max:Int):String=o.optString(k).trim().also { require(it.isNotEmpty() && it.length<=max) }
+    private inline fun <reified T: Enum<T>> enum(o:JSONObject,k:String,default:T):T = o.optString(k).let { runCatching { enumValueOf<T>(it) }.getOrDefault(default) }
+}

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogBackup.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogBackup.kt
@@ -3,45 +3,295 @@ package com.anezium.rokidbus.plugin.foodlog
 import org.json.JSONArray
 import org.json.JSONObject
 
-/** Bounded, versioned local backup codec. Parsing never accepts partial data. */
-internal object FoodLogBackup {
-    const val SCHEMA_VERSION = 2
-    private const val MAX_ENTRIES = 20_000
-    private const val MAX_TEXT = 300
+internal data class FoodLogArchive(
+    val entries: List<FoodEntry>,
+    val products: List<FoodProduct>,
+    val favoriteProductIds: Set<String>,
+    val goals: NutritionGoals?,
+    val recipes: List<FoodRecipe>,
+    val reminders: List<FoodLogReminder>,
+)
 
-    fun encode(entries: List<FoodEntry>): String = JSONObject().apply {
+/** Bounded, versioned local backup codec. Parsing validates the whole archive before import. */
+internal object FoodLogBackup {
+    const val SCHEMA_VERSION = 3
+    private const val LEGACY_SCHEMA_VERSION = 2
+    private const val MAX_ENTRIES = 20_000
+    private const val MAX_PRODUCTS = 20_000
+    private const val MAX_RECIPES = 5_000
+    private const val MAX_REMINDERS = 5_000
+    private const val MAX_TEXT = 300
+    private const val MAX_BACKUP_CHARS = 12_000_000
+
+    fun encode(archive: FoodLogArchive): String = JSONObject().apply {
         put("schemaVersion", SCHEMA_VERSION)
-        put("entries", JSONArray().apply { entries.forEach { put(it.toJson()) } })
+        put("products", JSONArray().apply { archive.products.forEach { put(it.toJson()) } })
+        put("entries", JSONArray().apply { archive.entries.forEach { put(it.toJson()) } })
+        put("favorites", JSONArray().apply { archive.favoriteProductIds.sorted().forEach(::put) })
+        put("goals", archive.goals?.toJson() ?: JSONObject.NULL)
+        put("recipes", JSONArray().apply { archive.recipes.forEach { put(it.toJson()) } })
+        put("reminders", JSONArray().apply { archive.reminders.forEach { put(it.toJson()) } })
     }.toString()
 
-    fun decode(text: String): List<FoodEntry> {
-        require(text.length <= 12_000_000) { "Backup is too large" }
+    fun decode(text: String): FoodLogArchive {
+        require(text.length <= MAX_BACKUP_CHARS) { "Backup is too large" }
         val root = JSONObject(text)
-        require(root.optInt("schemaVersion", -1) == SCHEMA_VERSION) { "Unsupported backup schema" }
-        val array = root.optJSONArray("entries") ?: throw IllegalArgumentException("Missing entries")
+        return when (root.optInt("schemaVersion", -1)) {
+            SCHEMA_VERSION -> decodeV3(root)
+            LEGACY_SCHEMA_VERSION -> decodeV2(root)
+            else -> throw IllegalArgumentException("Unsupported backup schema")
+        }
+    }
+
+    private fun decodeV3(root: JSONObject): FoodLogArchive {
+        val products = decodeProducts(requiredArray(root, "products"))
+        val productById = products.associateBy(FoodProduct::barcode)
+        require(productById.size == products.size) { "Duplicate product ID" }
+
+        val entries = decodeEntries(requiredArray(root, "entries"))
+        val favoritesArray = requiredArray(root, "favorites")
+        require(favoritesArray.length() <= MAX_PRODUCTS) { "Too many favorites" }
+        val favorites = buildSet {
+            for (index in 0 until favoritesArray.length()) {
+                val id = favoritesArray.getString(index)
+                require(productId(id) == id && productById.containsKey(id)) { "Invalid favorite product" }
+                require(add(id)) { "Duplicate favorite product" }
+            }
+        }
+        val goals = if (root.isNull("goals")) null else goalsFromJson(root.getJSONObject("goals"))
+        val recipes = decodeRecipes(requiredArray(root, "recipes"), productById)
+        val recipeIds = recipes.mapTo(hashSetOf(), FoodRecipe::uuid)
+        require(entries.all { it.recipeId == null || it.recipeId in recipeIds }) { "Missing entry recipe" }
+        val reminders = decodeReminders(requiredArray(root, "reminders"))
+        return FoodLogArchive(entries, products, favorites, goals, recipes, reminders)
+    }
+
+    private fun decodeV2(root: JSONObject): FoodLogArchive {
+        val entries = decodeEntries(requiredArray(root, "entries"))
+        val products = entries.asReversed().distinctBy { it.product.barcode }.map(FoodEntry::product)
+        return FoodLogArchive(entries, products, emptySet(), null, emptyList(), emptyList())
+    }
+
+    private fun decodeProducts(array: JSONArray): List<FoodProduct> {
+        require(array.length() <= MAX_PRODUCTS) { "Too many products" }
+        return List(array.length()) { productFromJson(array.getJSONObject(it)) }
+    }
+
+    private fun decodeEntries(array: JSONArray): List<FoodEntry> {
         require(array.length() <= MAX_ENTRIES) { "Too many entries" }
         val seen = HashSet<String>()
-        return List(array.length()) { index -> entryFromJson(array.getJSONObject(index)).also { require(seen.add(it.uuid)) { "Duplicate entry UUID" } } }
+        return List(array.length()) { index ->
+            entryFromJson(array.getJSONObject(index)).also {
+                require(seen.add(it.uuid)) { "Duplicate entry UUID" }
+            }
+        }
+    }
+
+    private fun decodeRecipes(array: JSONArray, products: Map<String, FoodProduct>): List<FoodRecipe> {
+        require(array.length() <= MAX_RECIPES) { "Too many recipes" }
+        val seen = HashSet<String>()
+        return List(array.length()) { index ->
+            val value = array.getJSONObject(index)
+            val uuid = requiredText(value, "uuid", 36)
+            require(seen.add(uuid)) { "Duplicate recipe UUID" }
+            val ingredientsArray = requiredArray(value, "ingredients")
+            require(ingredientsArray.length() in 1..MAX_RECIPE_INGREDIENTS) { "Invalid recipe ingredients" }
+            val ingredients = List(ingredientsArray.length()) { ingredientIndex ->
+                val ingredient = ingredientsArray.getJSONObject(ingredientIndex)
+                val productId = requiredText(ingredient, "productId", 70)
+                val product = products[productId] ?: throw IllegalArgumentException("Missing recipe product")
+                RecipeIngredient(product, requiredNumber(ingredient, "grams", MIN_QUANTITY_GRAMS, MAX_RECIPE_INGREDIENT_GRAMS))
+            }
+            FoodRecipe(
+                uuid = uuid,
+                name = requiredText(value, "name", MAX_RECIPE_NAME_CHARS),
+                servings = requiredNumber(value, "servings", 0.25, 100.0),
+                ingredients = ingredients,
+                createdAtMillis = requiredPositiveLong(value, "createdAtMillis"),
+            )
+        }
+    }
+
+    private fun decodeReminders(array: JSONArray): List<FoodLogReminder> {
+        require(array.length() <= MAX_REMINDERS) { "Too many reminders" }
+        val seen = HashSet<String>()
+        return List(array.length()) { index ->
+            val value = array.getJSONObject(index)
+            val id = requiredText(value, "id", 36)
+            require(FOOD_UUID_PATTERN.matches(id) && seen.add(id)) { "Invalid reminder UUID" }
+            FoodLogReminder(
+                id = id,
+                kind = requiredEnum(value, "kind"),
+                label = requiredText(value, "label", FoodLogReminderStore.MAX_LABEL_CHARS),
+                epochMillis = requiredPositiveLong(value, "epochMillis"),
+                enabled = value.getBoolean("enabled"),
+            )
+        }
     }
 
     private fun FoodEntry.toJson() = JSONObject().apply {
-        put("uuid", uuid); put("consumedAtMillis", consumedAtMillis); put("quantityGrams", quantityGrams)
-        put("mealType", mealType.name); put("source", source.name); put("recipeId", recipeId); put("product", product.toJson())
+        put("uuid", uuid)
+        put("consumedAtMillis", consumedAtMillis)
+        put("quantityGrams", quantityGrams)
+        put("mealType", mealType.name)
+        put("source", source.name)
+        put("recipeId", recipeId ?: JSONObject.NULL)
+        put("product", product.toJson())
     }
+
     private fun FoodProduct.toJson() = JSONObject().apply {
-        put("barcode", barcode); put("name", name); put("brand", brand); put("fetchedAtMillis", fetchedAtMillis)
-        put("nutrients", JSONObject().apply { nutrientsValues().forEach { put(it.first, it.second) } })
+        put("barcode", barcode)
+        put("name", name)
+        put("brand", brand)
+        put("servingLabel", servingLabel ?: JSONObject.NULL)
+        put("servingGrams", servingGrams ?: JSONObject.NULL)
+        put("nutritionGrade", nutritionGrade ?: JSONObject.NULL)
+        put("novaGroup", novaGroup ?: JSONObject.NULL)
+        put("fetchedAtMillis", fetchedAtMillis)
+        put("nutrients", JSONObject().apply {
+            nutrientValues().forEach { (key, value) -> put(key, value ?: JSONObject.NULL) }
+        })
     }
-    private fun FoodProduct.nutrientsValues() = listOf("calories" to nutrients.caloriesKcal,"protein" to nutrients.proteinGrams,"carbohydrate" to nutrients.carbohydrateGrams,"fat" to nutrients.fatGrams,"sugars" to nutrients.sugarsGrams,"fiber" to nutrients.fiberGrams,"salt" to nutrients.saltGrams,"saturatedFat" to nutrients.saturatedFatGrams,"sodium" to nutrients.sodiumMilligrams,"cholesterol" to nutrients.cholesterolMilligrams,"potassium" to nutrients.potassiumMilligrams,"calcium" to nutrients.calciumMilligrams,"iron" to nutrients.ironMilligrams,"caffeine" to nutrients.caffeineMilligrams)
-    private fun entryFromJson(o: JSONObject): FoodEntry {
-        val uuid = text(o,"uuid",64); require(uuid.matches(Regex("[A-Za-z0-9-]{1,64}")))
-        val quantity=o.optDouble("quantityGrams",Double.NaN); require(quantity in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS)
-        val consumed=o.optLong("consumedAtMillis",Long.MIN_VALUE); require(consumed > 0)
-        val p=o.optJSONObject("product") ?: throw IllegalArgumentException("Missing product")
-        val barcode = text(p,"barcode",70); require(productId(barcode) != null)
-        return FoodEntry(0,consumed,quantity,FoodProduct(barcode,text(p,"name",MAX_TEXT),text(p,"brand",MAX_TEXT),null,null,null,null,nutrients(p.optJSONObject("nutrients") ?: throw IllegalArgumentException("Missing nutrients")),p.optLong("fetchedAtMillis",0)),uuid,enum(o,"mealType",MealType.UNKNOWN),enum(o,"source",FoodEntrySource.UNKNOWN),o.optString("recipeId").takeIf { it.isNotBlank() && it.length <= 64 })
+
+    private fun NutritionGoals.toJson() = JSONObject().apply {
+        put("calories", caloriesKcal ?: JSONObject.NULL)
+        put("protein", proteinGrams ?: JSONObject.NULL)
+        put("carbohydrate", carbohydrateGrams ?: JSONObject.NULL)
+        put("fat", fatGrams ?: JSONObject.NULL)
     }
-    private fun nutrients(o: JSONObject): NutrientsPer100g { fun n(k:String)=if(!o.has(k)||o.isNull(k))null else o.optDouble(k,Double.NaN).takeIf { it.isFinite() && it>=0 }; return NutrientsPer100g(n("calories"),n("protein"),n("carbohydrate"),n("fat"),n("sugars"),n("fiber"),n("salt"),n("saturatedFat"),n("sodium"),n("cholesterol"),n("potassium"),n("calcium"),n("iron"),n("caffeine")) }
-    private fun text(o:JSONObject,k:String,max:Int):String=o.optString(k).trim().also { require(it.isNotEmpty() && it.length<=max) }
-    private inline fun <reified T: Enum<T>> enum(o:JSONObject,k:String,default:T):T = o.optString(k).let { runCatching { enumValueOf<T>(it) }.getOrDefault(default) }
+
+    private fun FoodRecipe.toJson() = JSONObject().apply {
+        put("uuid", uuid)
+        put("name", name)
+        put("servings", servings)
+        put("createdAtMillis", createdAtMillis)
+        put("ingredients", JSONArray().apply {
+            ingredients.forEach { ingredient ->
+                put(JSONObject().put("productId", ingredient.product.barcode).put("grams", ingredient.grams))
+            }
+        })
+    }
+
+    private fun FoodLogReminder.toJson() = JSONObject()
+        .put("id", id)
+        .put("kind", kind.name)
+        .put("label", label)
+        .put("epochMillis", epochMillis)
+        .put("enabled", enabled)
+
+    private fun FoodProduct.nutrientValues() = listOf(
+        "calories" to nutrients.caloriesKcal,
+        "protein" to nutrients.proteinGrams,
+        "carbohydrate" to nutrients.carbohydrateGrams,
+        "fat" to nutrients.fatGrams,
+        "sugars" to nutrients.sugarsGrams,
+        "fiber" to nutrients.fiberGrams,
+        "salt" to nutrients.saltGrams,
+        "saturatedFat" to nutrients.saturatedFatGrams,
+        "sodium" to nutrients.sodiumMilligrams,
+        "cholesterol" to nutrients.cholesterolMilligrams,
+        "potassium" to nutrients.potassiumMilligrams,
+        "calcium" to nutrients.calciumMilligrams,
+        "iron" to nutrients.ironMilligrams,
+        "caffeine" to nutrients.caffeineMilligrams,
+    )
+
+    private fun entryFromJson(value: JSONObject): FoodEntry {
+        val uuid = requiredText(value, "uuid", 64)
+        require(FOOD_ENTRY_ID_PATTERN.matches(uuid)) { "Invalid entry UUID" }
+        val recipeId = optionalText(value, "recipeId", 36)?.also {
+            require(FOOD_UUID_PATTERN.matches(it)) { "Invalid recipe UUID" }
+        }
+        return FoodEntry(
+            id = 0,
+            consumedAtMillis = requiredPositiveLong(value, "consumedAtMillis"),
+            quantityGrams = requiredNumber(value, "quantityGrams", MIN_QUANTITY_GRAMS, MAX_QUANTITY_GRAMS),
+            product = productFromJson(value.getJSONObject("product")),
+            uuid = uuid,
+            mealType = requiredEnum(value, "mealType"),
+            source = requiredEnum(value, "source"),
+            recipeId = recipeId,
+        )
+    }
+
+    private fun productFromJson(value: JSONObject): FoodProduct {
+        val barcode = requiredText(value, "barcode", 70)
+        require(productId(barcode) == barcode) { "Invalid product ID" }
+        val servingGrams = optionalNumber(value, "servingGrams", 0.01, MAX_RECIPE_INGREDIENT_GRAMS)
+        val novaGroup = if (!value.has("novaGroup") || value.isNull("novaGroup")) null else value.getInt("novaGroup").also {
+            require(it in 1..4) { "Invalid NOVA group" }
+        }
+        val fetchedAt = value.optLong("fetchedAtMillis", 0L)
+        require(fetchedAt >= 0L) { "Invalid fetched time" }
+        return FoodProduct(
+            barcode = barcode,
+            name = requiredText(value, "name", MAX_TEXT),
+            brand = boundedText(value, "brand", MAX_TEXT),
+            servingLabel = optionalText(value, "servingLabel", MAX_TEXT),
+            servingGrams = servingGrams,
+            nutritionGrade = optionalText(value, "nutritionGrade", 20),
+            novaGroup = novaGroup,
+            nutrients = nutrients(value.getJSONObject("nutrients")),
+            fetchedAtMillis = fetchedAt,
+        )
+    }
+
+    private fun goalsFromJson(value: JSONObject) = NutritionGoals(
+        caloriesKcal = optionalNumber(value, "calories", 1.0, 20_000.0),
+        proteinGrams = optionalNumber(value, "protein", 1.0, 2_000.0),
+        carbohydrateGrams = optionalNumber(value, "carbohydrate", 1.0, 3_000.0),
+        fatGrams = optionalNumber(value, "fat", 1.0, 2_000.0),
+    )
+
+    private fun nutrients(value: JSONObject): NutrientsPer100g = NutrientsPer100g(
+        caloriesKcal = nutrient(value, "calories"),
+        proteinGrams = nutrient(value, "protein"),
+        carbohydrateGrams = nutrient(value, "carbohydrate"),
+        fatGrams = nutrient(value, "fat"),
+        sugarsGrams = nutrient(value, "sugars"),
+        fiberGrams = nutrient(value, "fiber"),
+        saltGrams = nutrient(value, "salt"),
+        saturatedFatGrams = nutrient(value, "saturatedFat"),
+        sodiumMilligrams = nutrient(value, "sodium"),
+        cholesterolMilligrams = nutrient(value, "cholesterol"),
+        potassiumMilligrams = nutrient(value, "potassium"),
+        calciumMilligrams = nutrient(value, "calcium"),
+        ironMilligrams = nutrient(value, "iron"),
+        caffeineMilligrams = nutrient(value, "caffeine"),
+    )
+
+    private fun nutrient(value: JSONObject, key: String): Double? =
+        optionalNumber(value, key, 0.0, 1_000_000_000.0)
+
+    private fun requiredArray(value: JSONObject, key: String): JSONArray =
+        value.optJSONArray(key) ?: throw IllegalArgumentException("Missing $key")
+
+    private fun requiredPositiveLong(value: JSONObject, key: String): Long = value.getLong(key).also {
+        require(it > 0L) { "Invalid $key" }
+    }
+
+    private fun requiredNumber(value: JSONObject, key: String, minimum: Double, maximum: Double): Double =
+        value.getDouble(key).also { require(it.isFinite() && it in minimum..maximum) { "Invalid $key" } }
+
+    private fun optionalNumber(value: JSONObject, key: String, minimum: Double, maximum: Double): Double? {
+        if (!value.has(key) || value.isNull(key)) return null
+        return requiredNumber(value, key, minimum, maximum)
+    }
+
+    private fun requiredText(value: JSONObject, key: String, maximum: Int): String =
+        boundedText(value, key, maximum).also { require(it.isNotEmpty()) { "Missing $key" } }
+
+    private fun boundedText(value: JSONObject, key: String, maximum: Int): String =
+        value.getString(key).trim().also { require(it.length <= maximum) { "$key is too long" } }
+
+    private fun optionalText(value: JSONObject, key: String, maximum: Int): String? {
+        if (!value.has(key) || value.isNull(key)) return null
+        return boundedText(value, key, maximum).takeIf(String::isNotEmpty)
+    }
+
+    private inline fun <reified T : Enum<T>> requiredEnum(value: JSONObject, key: String): T {
+        val raw = requiredText(value, key, 40)
+        return enumValues<T>().firstOrNull { it.name == raw }
+            ?: throw IllegalArgumentException("Invalid $key")
+    }
 }

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogHealthConnectBridge.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogHealthConnectBridge.kt
@@ -2,14 +2,15 @@ package com.anezium.rokidbus.plugin.foodlog
 
 import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
-import androidx.health.connect.client.HealthPermission
-import androidx.health.connect.client.records.MealType
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.MealType as HealthMealType
 import androidx.health.connect.client.records.NutritionRecord
 import androidx.health.connect.client.records.metadata.Metadata
 import androidx.health.connect.client.units.Energy
 import androidx.health.connect.client.units.Mass
 import java.time.Instant
 import java.time.ZoneId
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Writes a Food Log entry only after the caller has obtained an explicit user opt-in.
@@ -40,10 +41,7 @@ internal class FoodLogHealthConnectBridge(
             .contains(WRITE_NUTRITION_PERMISSION)
     }
 
-    /**
-     * Uses the documented client-record-ID upsert semantics. Entries are immutable, so their
-     * consumed timestamp is a stable version; a repeated request is therefore idempotent.
-     */
+    /** Uses a stable client record ID and a monotonic version so meal edits replace prior writes. */
     suspend fun syncEntry(
         entry: FoodEntry,
         userOptedIn: Boolean,
@@ -68,10 +66,47 @@ internal class FoodLogHealthConnectBridge(
         if (!hasPermission) return FoodLogHealthConnectSyncResult.PermissionRequired
 
         return try {
-            client.insertRecords(listOf(entry.toNutritionRecord(zoneId)))
+            client.insertRecords(
+                listOf(entry.toNutritionRecord(zoneId, syncVersionMillis = nextHealthConnectVersion())),
+            )
             FoodLogHealthConnectSyncResult.Synced
         } catch (exception: SecurityException) {
             // Permissions can be revoked after the check above.
+            FoodLogHealthConnectSyncResult.PermissionRequired
+        } catch (exception: Exception) {
+            FoodLogHealthConnectSyncResult.Failed(exception.safeMessage())
+        }
+    }
+
+    /** Removes only the record previously written for this exact local entry. */
+    suspend fun deleteEntry(
+        entry: FoodEntry,
+        userOptedIn: Boolean,
+    ): FoodLogHealthConnectSyncResult {
+        if (!userOptedIn) return FoodLogHealthConnectSyncResult.NotOptedIn
+        when (val status = availability()) {
+            FoodLogHealthConnectAvailability.Available -> Unit
+            else -> return FoodLogHealthConnectSyncResult.Unavailable(status)
+        }
+        val client = try {
+            clientFactory(appContext)
+        } catch (exception: Exception) {
+            return FoodLogHealthConnectSyncResult.Failed(exception.safeMessage())
+        }
+        val hasPermission = try {
+            client.permissionController.getGrantedPermissions().contains(WRITE_NUTRITION_PERMISSION)
+        } catch (exception: Exception) {
+            return FoodLogHealthConnectSyncResult.Failed(exception.safeMessage())
+        }
+        if (!hasPermission) return FoodLogHealthConnectSyncResult.PermissionRequired
+        return try {
+            client.deleteRecords(
+                NutritionRecord::class,
+                emptyList(),
+                listOf(entry.healthConnectClientRecordId()),
+            )
+            FoodLogHealthConnectSyncResult.Synced
+        } catch (exception: SecurityException) {
             FoodLogHealthConnectSyncResult.PermissionRequired
         } catch (exception: Exception) {
             FoodLogHealthConnectSyncResult.Failed(exception.safeMessage())
@@ -99,11 +134,16 @@ internal sealed interface FoodLogHealthConnectSyncResult {
     data class Failed(val reason: String) : FoodLogHealthConnectSyncResult
 }
 
-internal fun FoodEntry.healthConnectClientRecordId(): String = "foodlog-entry-$id"
+internal fun FoodEntry.healthConnectClientRecordId(): String =
+    "foodlog-entry-${uuid.ifBlank { id.toString() }}"
 
-internal fun FoodEntry.healthConnectClientRecordVersion(): Long = consumedAtMillis.coerceAtLeast(1L)
+internal fun FoodEntry.healthConnectClientRecordVersion(syncVersionMillis: Long): Long =
+    maxOf(consumedAtMillis, syncVersionMillis).coerceAtLeast(1L)
 
-internal fun FoodEntry.toNutritionRecord(zoneId: ZoneId): NutritionRecord {
+internal fun FoodEntry.toNutritionRecord(
+    zoneId: ZoneId,
+    syncVersionMillis: Long = System.currentTimeMillis(),
+): NutritionRecord {
     val consumedAt = Instant.ofEpochMilli(consumedAtMillis)
     val endTime = consumedAt.plusMillis(1)
     val zoneOffset = zoneId.rules.getOffset(consumedAt)
@@ -115,7 +155,7 @@ internal fun FoodEntry.toNutritionRecord(zoneId: ZoneId): NutritionRecord {
         endZoneOffset = zoneId.rules.getOffset(endTime),
         metadata = Metadata.manualEntry(
             clientRecordId = healthConnectClientRecordId(),
-            clientRecordVersion = healthConnectClientRecordVersion(),
+            clientRecordVersion = healthConnectClientRecordVersion(syncVersionMillis),
         ),
         energy = nutrients.caloriesKcal.scaledEnergy(entry = this),
         protein = nutrients.proteinGrams.scaledMass(entry = this),
@@ -123,24 +163,39 @@ internal fun FoodEntry.toNutritionRecord(zoneId: ZoneId): NutritionRecord {
         totalFat = nutrients.fatGrams.scaledMass(entry = this),
         sugar = nutrients.sugarsGrams.scaledMass(entry = this),
         dietaryFiber = nutrients.fiberGrams.scaledMass(entry = this),
-        // Open Food Facts' salt value is sodium chloride. Health Connect expects sodium.
-        sodium = nutrients.saltGrams?.div(SALT_GRAMS_PER_SODIUM_GRAM)?.scaledMass(entry = this),
+        saturatedFat = nutrients.saturatedFatGrams.scaledMass(entry = this),
+        sodium = nutrients.sodiumMilligrams.scaledMilligrams(entry = this)
+            // Open Food Facts' salt value is sodium chloride. Health Connect expects sodium.
+            ?: nutrients.saltGrams?.div(SALT_GRAMS_PER_SODIUM_GRAM)?.scaledMass(entry = this),
+        cholesterol = nutrients.cholesterolMilligrams.scaledMilligrams(entry = this),
+        potassium = nutrients.potassiumMilligrams.scaledMilligrams(entry = this),
+        calcium = nutrients.calciumMilligrams.scaledMilligrams(entry = this),
+        iron = nutrients.ironMilligrams.scaledMilligrams(entry = this),
+        caffeine = nutrients.caffeineMilligrams.scaledMilligrams(entry = this),
         name = product.name,
-        mealType = mealTypeFor(consumedAt, zoneId),
+        mealType = mealType.toHealthConnectMealType(consumedAt, zoneId),
     )
 }
 
-internal fun mealTypeFor(consumedAt: Instant, zoneId: ZoneId): Int = when (
-    consumedAt.atZone(zoneId).hour
-) {
-    in 5..10 -> MealType.MEAL_TYPE_BREAKFAST
-    in 11..15 -> MealType.MEAL_TYPE_LUNCH
-    in 16..22 -> MealType.MEAL_TYPE_DINNER
-    else -> MealType.MEAL_TYPE_SNACK
+internal fun MealType.toHealthConnectMealType(consumedAt: Instant, zoneId: ZoneId): Int = when (this) {
+    MealType.BREAKFAST -> HealthMealType.MEAL_TYPE_BREAKFAST
+    MealType.LUNCH -> HealthMealType.MEAL_TYPE_LUNCH
+    MealType.DINNER -> HealthMealType.MEAL_TYPE_DINNER
+    MealType.SNACK -> HealthMealType.MEAL_TYPE_SNACK
+    MealType.UNKNOWN -> when (inferredMealType(consumedAt.toEpochMilli(), zoneId)) {
+        MealType.BREAKFAST -> HealthMealType.MEAL_TYPE_BREAKFAST
+        MealType.LUNCH -> HealthMealType.MEAL_TYPE_LUNCH
+        MealType.DINNER -> HealthMealType.MEAL_TYPE_DINNER
+        MealType.SNACK -> HealthMealType.MEAL_TYPE_SNACK
+        MealType.UNKNOWN -> HealthMealType.MEAL_TYPE_UNKNOWN
+    }
 }
 
 private fun Double?.scaledMass(entry: FoodEntry): Mass? =
     scaledValue(this, entry.quantityGrams)?.let(Mass::grams)
+
+private fun Double?.scaledMilligrams(entry: FoodEntry): Mass? =
+    scaledValue(this, entry.quantityGrams)?.let(Mass::milligrams)
 
 private fun Double?.scaledEnergy(entry: FoodEntry): Energy? =
     scaledValue(this, entry.quantityGrams)?.let(Energy::kilocalories)
@@ -148,3 +203,10 @@ private fun Double?.scaledEnergy(entry: FoodEntry): Energy? =
 private fun Exception.safeMessage(): String = message ?: javaClass.simpleName
 
 private const val SALT_GRAMS_PER_SODIUM_GRAM = 2.5
+private val healthConnectVersionClock = AtomicLong(System.currentTimeMillis() * 1_000L)
+private fun nextHealthConnectVersion(): Long = healthConnectVersionClock.updateAndGet { previous ->
+    maxOf(previous + 1L, System.currentTimeMillis() * 1_000L)
+}
+
+internal const val FOOD_LOG_PREFERENCES = "food_log_settings"
+internal const val FOOD_LOG_HEALTH_SYNC_KEY = "health_connect_write_enabled"

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogHealthConnectBridge.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogHealthConnectBridge.kt
@@ -1,0 +1,150 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import android.content.Context
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.HealthPermission
+import androidx.health.connect.client.records.MealType
+import androidx.health.connect.client.records.NutritionRecord
+import androidx.health.connect.client.records.metadata.Metadata
+import androidx.health.connect.client.units.Energy
+import androidx.health.connect.client.units.Mass
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * Writes a Food Log entry only after the caller has obtained an explicit user opt-in.
+ *
+ * The caller owns both presenting Health Connect's permission UI and persisting the opt-in;
+ * this bridge deliberately has no background or automatic synchronization path.
+ */
+internal class FoodLogHealthConnectBridge(
+    context: Context,
+    private val clientFactory: (Context) -> HealthConnectClient = HealthConnectClient::getOrCreate,
+) {
+    private val appContext = context.applicationContext
+
+    fun availability(): FoodLogHealthConnectAvailability = when (
+        HealthConnectClient.getSdkStatus(appContext)
+    ) {
+        HealthConnectClient.SDK_AVAILABLE -> FoodLogHealthConnectAvailability.Available
+        HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED ->
+            FoodLogHealthConnectAvailability.ProviderUpdateRequired
+        else -> FoodLogHealthConnectAvailability.Unavailable
+    }
+
+    suspend fun hasWriteNutritionPermission(): Boolean {
+        if (availability() != FoodLogHealthConnectAvailability.Available) return false
+        return clientFactory(appContext)
+            .permissionController
+            .getGrantedPermissions()
+            .contains(WRITE_NUTRITION_PERMISSION)
+    }
+
+    /**
+     * Uses the documented client-record-ID upsert semantics. Entries are immutable, so their
+     * consumed timestamp is a stable version; a repeated request is therefore idempotent.
+     */
+    suspend fun syncEntry(
+        entry: FoodEntry,
+        userOptedIn: Boolean,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): FoodLogHealthConnectSyncResult {
+        if (!userOptedIn) return FoodLogHealthConnectSyncResult.NotOptedIn
+        when (val status = availability()) {
+            FoodLogHealthConnectAvailability.Available -> Unit
+            else -> return FoodLogHealthConnectSyncResult.Unavailable(status)
+        }
+
+        val client = try {
+            clientFactory(appContext)
+        } catch (exception: Exception) {
+            return FoodLogHealthConnectSyncResult.Failed(exception.safeMessage())
+        }
+        val hasPermission = try {
+            client.permissionController.getGrantedPermissions().contains(WRITE_NUTRITION_PERMISSION)
+        } catch (exception: Exception) {
+            return FoodLogHealthConnectSyncResult.Failed(exception.safeMessage())
+        }
+        if (!hasPermission) return FoodLogHealthConnectSyncResult.PermissionRequired
+
+        return try {
+            client.insertRecords(listOf(entry.toNutritionRecord(zoneId)))
+            FoodLogHealthConnectSyncResult.Synced
+        } catch (exception: SecurityException) {
+            // Permissions can be revoked after the check above.
+            FoodLogHealthConnectSyncResult.PermissionRequired
+        } catch (exception: Exception) {
+            FoodLogHealthConnectSyncResult.Failed(exception.safeMessage())
+        }
+    }
+
+    companion object {
+        val WRITE_NUTRITION_PERMISSION: String =
+            HealthPermission.getWritePermission(NutritionRecord::class)
+    }
+}
+
+internal sealed interface FoodLogHealthConnectAvailability {
+    data object Available : FoodLogHealthConnectAvailability
+    data object ProviderUpdateRequired : FoodLogHealthConnectAvailability
+    data object Unavailable : FoodLogHealthConnectAvailability
+}
+
+internal sealed interface FoodLogHealthConnectSyncResult {
+    data object Synced : FoodLogHealthConnectSyncResult
+    data object NotOptedIn : FoodLogHealthConnectSyncResult
+    data object PermissionRequired : FoodLogHealthConnectSyncResult
+    data class Unavailable(val availability: FoodLogHealthConnectAvailability) :
+        FoodLogHealthConnectSyncResult
+    data class Failed(val reason: String) : FoodLogHealthConnectSyncResult
+}
+
+internal fun FoodEntry.healthConnectClientRecordId(): String = "foodlog-entry-$id"
+
+internal fun FoodEntry.healthConnectClientRecordVersion(): Long = consumedAtMillis.coerceAtLeast(1L)
+
+internal fun FoodEntry.toNutritionRecord(zoneId: ZoneId): NutritionRecord {
+    val consumedAt = Instant.ofEpochMilli(consumedAtMillis)
+    val endTime = consumedAt.plusMillis(1)
+    val zoneOffset = zoneId.rules.getOffset(consumedAt)
+    val nutrients = product.nutrients
+    return NutritionRecord(
+        startTime = consumedAt,
+        startZoneOffset = zoneOffset,
+        endTime = endTime,
+        endZoneOffset = zoneId.rules.getOffset(endTime),
+        metadata = Metadata.manualEntry(
+            clientRecordId = healthConnectClientRecordId(),
+            clientRecordVersion = healthConnectClientRecordVersion(),
+        ),
+        energy = nutrients.caloriesKcal.scaledEnergy(entry = this),
+        protein = nutrients.proteinGrams.scaledMass(entry = this),
+        totalCarbohydrate = nutrients.carbohydrateGrams.scaledMass(entry = this),
+        totalFat = nutrients.fatGrams.scaledMass(entry = this),
+        sugar = nutrients.sugarsGrams.scaledMass(entry = this),
+        dietaryFiber = nutrients.fiberGrams.scaledMass(entry = this),
+        // Open Food Facts' salt value is sodium chloride. Health Connect expects sodium.
+        sodium = nutrients.saltGrams?.div(SALT_GRAMS_PER_SODIUM_GRAM)?.scaledMass(entry = this),
+        name = product.name,
+        mealType = mealTypeFor(consumedAt, zoneId),
+    )
+}
+
+internal fun mealTypeFor(consumedAt: Instant, zoneId: ZoneId): Int = when (
+    consumedAt.atZone(zoneId).hour
+) {
+    in 5..10 -> MealType.MEAL_TYPE_BREAKFAST
+    in 11..15 -> MealType.MEAL_TYPE_LUNCH
+    in 16..22 -> MealType.MEAL_TYPE_DINNER
+    else -> MealType.MEAL_TYPE_SNACK
+}
+
+private fun Double?.scaledMass(entry: FoodEntry): Mass? =
+    scaledValue(this, entry.quantityGrams)?.let(Mass::grams)
+
+private fun Double?.scaledEnergy(entry: FoodEntry): Energy? =
+    scaledValue(this, entry.quantityGrams)?.let(Energy::kilocalories)
+
+private fun Exception.safeMessage(): String = message ?: javaClass.simpleName
+
+private const val SALT_GRAMS_PER_SODIUM_GRAM = 2.5

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogHealthRationaleActivity.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogHealthRationaleActivity.kt
@@ -1,0 +1,54 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import com.anezium.rokidbus.client.ui.BusTheme
+import com.anezium.rokidbus.client.ui.NexusPluginIcons
+import com.anezium.rokidbus.client.ui.NexusUi
+
+/** Privacy policy shown from Health Connect's permission surface. */
+class FoodLogHealthRationaleActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.statusBarColor = NexusUi.BG
+        window.navigationBarColor = NexusUi.BG
+        val content = NexusUi.contentColumn(this).apply {
+            addView(NexusUi.sectionRow(this@FoodLogHealthRationaleActivity, "Health Connect"), NexusUi.block())
+            addView(BusTheme.gap(this@FoodLogHealthRationaleActivity, 10))
+            addView(
+                NexusUi.card(this@FoodLogHealthRationaleActivity).apply {
+                    addView(NexusUi.cardTitle(this@FoodLogHealthRationaleActivity, "Your nutrition stays under your control"))
+                    addView(BusTheme.gap(this@FoodLogHealthRationaleActivity, 8))
+                    addView(
+                        NexusUi.cardBody(
+                            this@FoodLogHealthRationaleActivity,
+                            "Food Log only asks for permission to write nutrition records. It never reads Health Connect. " +
+                                "Synchronization is off by default and only runs after you enable it in Food Log. " +
+                                "Your local journal remains the source of truth, and no food history is sent to Rokid Nexus or Open Food Facts.",
+                        ),
+                    )
+                },
+                NexusUi.block(),
+            )
+        }
+        setContentView(
+            NexusUi.fixedRoot(this).apply {
+                addView(
+                    NexusUi.pluginHeader(
+                        this@FoodLogHealthRationaleActivity,
+                        NexusPluginIcons.drawableFor("heart"),
+                        "Food Log privacy",
+                        "Health Connect rationale",
+                    ),
+                    NexusUi.block(),
+                )
+                addView(
+                    NexusUi.screen(this@FoodLogHealthRationaleActivity, content),
+                    LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f),
+                )
+            },
+        )
+    }
+}

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogPluginService.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogPluginService.kt
@@ -11,6 +11,11 @@ import com.anezium.rokidbus.client.plugin.NexusSdkResult
 import com.anezium.rokidbus.client.plugin.NexusSnapshotCallbacks
 import com.anezium.rokidbus.client.plugin.NexusSnapshotError
 import com.anezium.rokidbus.client.plugin.NexusSnapshotSession
+import com.anezium.rokidbus.client.plugin.NexusSpeechCallbacks
+import com.anezium.rokidbus.client.plugin.NexusSpeechError
+import com.anezium.rokidbus.client.plugin.NexusSpeechSession
+import com.anezium.rokidbus.client.plugin.NexusSpeechState
+import com.anezium.rokidbus.client.plugin.NexusSpeechStopReason
 import com.anezium.rokidbus.client.plugin.NexusSurfaceSession
 import com.anezium.rokidbus.shared.plugin.NexusInputEvent
 import java.time.Instant
@@ -27,6 +32,7 @@ class FoodLogPluginService : NexusPluginService() {
 
     private var surface: NexusSurfaceSession? = null
     private var snapshotSession: NexusSnapshotSession? = null
+    private var speechSession: NexusSpeechSession? = null
     private var generation = 0L
     private var screen = Screen.HOME
     private var selectedIndex = 0
@@ -37,6 +43,57 @@ class FoodLogPluginService : NexusPluginService() {
     private var undoCandidate: FoodEntry? = null
     private var messageTitle = "Food Log"
     private var messageLines = emptyList<String>()
+    private val voiceFinalSegments = mutableListOf<String>()
+    private var voicePartial = ""
+    private var voiceStatus = "Starting…"
+    private var stopVoiceWhenStarted = false
+    private val speechCallbacks = object : NexusSpeechCallbacks {
+        override fun onSpeechStarted(realtime: Boolean) {
+            val active = speechSession ?: return
+            if (stopVoiceWhenStarted || screen != Screen.VOICE) {
+                active.stop()
+                return
+            }
+            voiceStatus = if (realtime) "Listening…" else "Listening in batch mode…"
+            render(show = false)
+        }
+
+        override fun onSpeechState(state: NexusSpeechState) {
+            if (screen != Screen.VOICE) return
+            voiceStatus = when (state) {
+                NexusSpeechState.LISTENING -> "Listening…"
+                NexusSpeechState.RECOGNIZING -> "Recognizing…"
+                NexusSpeechState.PROCESSING -> "Processing…"
+            }
+            render(show = false)
+        }
+
+        override fun onSpeechPartial(text: String) {
+            if (screen != Screen.VOICE) return
+            voicePartial = text.trim().take(MAX_VOICE_TRANSCRIPT_CHARS)
+            render(show = false)
+        }
+
+        override fun onSpeechFinal(text: String) {
+            if (screen != Screen.VOICE) return
+            text.trim().takeIf(String::isNotBlank)?.let { segment ->
+                voiceFinalSegments += segment.take(MAX_VOICE_TRANSCRIPT_CHARS)
+            }
+            voicePartial = ""
+            render(show = false)
+        }
+
+        override fun onSpeechStopped(reason: NexusSpeechStopReason, error: NexusSpeechError?) {
+            speechSession = null
+            stopVoiceWhenStarted = false
+            if (screen != Screen.VOICE) return
+            if (reason != NexusSpeechStopReason.COMPLETED && voiceTranscript().isBlank()) {
+                showMessage("Voice entry", voiceStopMessage(reason, error))
+                return
+            }
+            resolveVoiceTranscript()
+        }
+    }
 
     override fun onNexusOpen() {
         generation += 1
@@ -44,6 +101,7 @@ class FoodLogPluginService : NexusPluginService() {
         selectedIndex = 0
         selectedProduct = null
         undoCandidate = null
+        clearVoice()
         refreshLocalState()
         surface = nexusSurfaceSession(SURFACE_ID)
         render(show = true)
@@ -53,17 +111,24 @@ class FoodLogPluginService : NexusPluginService() {
         generation += 1
         snapshotSession?.cancel()
         snapshotSession = null
+        stopVoiceWhenStarted = true
+        speechSession?.stop()
+        speechSession = null
         surface?.hide()
         surface = null
         selectedProduct = null
         undoCandidate = null
         screen = Screen.HOME
+        clearVoice()
     }
 
     override fun onDestroy() {
         generation += 1
         snapshotSession?.cancel()
         snapshotSession = null
+        stopVoiceWhenStarted = true
+        speechSession?.stop()
+        speechSession = null
         barcodeScanner.close()
         ioExecutor.shutdownNow()
         store.close()
@@ -109,9 +174,10 @@ class FoodLogPluginService : NexusPluginService() {
         when (screen) {
             Screen.HOME -> when (selectedIndex) {
                 0 -> startSnapshot()
-                1 -> showToday()
-                2 -> showRecents()
-                3 -> confirmUndo()
+                1 -> startVoiceEntry()
+                2 -> showToday()
+                3 -> showRecents()
+                4 -> confirmUndo()
             }
             Screen.PRODUCT -> {
                 screen = Screen.PORTION
@@ -120,6 +186,10 @@ class FoodLogPluginService : NexusPluginService() {
             Screen.PORTION -> addSelectedProduct()
             Screen.RECENTS -> recentProducts.getOrNull(selectedIndex)?.let(::showProduct)
             Screen.CONFIRM_UNDO -> deleteUndoCandidate()
+            Screen.VOICE -> {
+                stopVoiceWhenStarted = true
+                speechSession?.stop()
+            }
             Screen.MESSAGE -> showHome()
             Screen.TODAY,
             Screen.SCANNING,
@@ -135,6 +205,9 @@ class FoodLogPluginService : NexusPluginService() {
         generation += 1
         snapshotSession?.cancel()
         snapshotSession = null
+        stopVoiceWhenStarted = true
+        speechSession?.stop()
+        speechSession = null
         showHome()
     }
 
@@ -144,6 +217,7 @@ class FoodLogPluginService : NexusPluginService() {
         selectedIndex = 0
         selectedProduct = null
         undoCandidate = null
+        clearVoice()
         render(show = false)
     }
 
@@ -252,6 +326,82 @@ class FoodLogPluginService : NexusPluginService() {
         }
     }
 
+    private fun startVoiceEntry() {
+        refreshLocalState()
+        if (recentProducts.isEmpty()) {
+            showMessage(
+                "Voice entry",
+                "Log or create a food on the phone first, then say its name.",
+            )
+            return
+        }
+        clearVoice()
+        screen = Screen.VOICE
+        render(show = false)
+        val session = nexusSpeechSession(speechCallbacks)
+        speechSession = session
+        val result = session?.start()
+        if (result != NexusSdkResult.SENT) {
+            speechSession = null
+            val message = when (result) {
+                NexusSdkResult.CAPABILITY_NOT_GRANTED ->
+                    "Grant Speech to text access to Food Log in Nexus settings."
+                NexusSdkResult.CAPABILITY_NOT_AVAILABLE -> "Speech recognition is unavailable."
+                else -> "Speech recognition could not start."
+            }
+            showMessage("Voice entry", message)
+        }
+    }
+
+    private fun resolveVoiceTranscript() {
+        when (val match = FoodVoiceParser.match(voiceTranscript(), recentProducts)) {
+            is FoodVoiceMatch.Matched -> {
+                selectedProduct = match.product
+                quantityGrams = match.quantityGrams
+                screen = Screen.PORTION
+                render(show = false)
+            }
+            is FoodVoiceMatch.Ambiguous -> showMessage(
+                "Several foods match",
+                match.products.joinToString(" · ") { it.name }.hud(240),
+                "Try again with a more precise name.",
+            )
+            FoodVoiceMatch.InvalidQuantity -> showMessage(
+                "Invalid amount",
+                "Say an amount between 1 and 5,000 grams.",
+            )
+            FoodVoiceMatch.NoProduct -> showMessage(
+                "Food not recognized",
+                "Try the exact name of a recent food.",
+            )
+        }
+    }
+
+    private fun voiceTranscript(): String =
+        (voiceFinalSegments + listOfNotNull(voicePartial.takeIf(String::isNotBlank)))
+            .joinToString(" ")
+            .trim()
+            .take(MAX_VOICE_TRANSCRIPT_CHARS)
+
+    private fun clearVoice() {
+        voiceFinalSegments.clear()
+        voicePartial = ""
+        voiceStatus = "Starting…"
+        stopVoiceWhenStarted = false
+    }
+
+    private fun voiceStopMessage(reason: NexusSpeechStopReason, error: NexusSpeechError?): String = when (reason) {
+        NexusSpeechStopReason.NO_SPEECH -> "No speech was detected."
+        NexusSpeechStopReason.LINK_LOST -> "The glasses link was lost."
+        NexusSpeechStopReason.REVOKED -> "Speech access was revoked."
+        NexusSpeechStopReason.DENIED_BUSY -> "Speech recognition is already busy."
+        NexusSpeechStopReason.DENIED_NO_LINK -> "The glasses link is unavailable."
+        NexusSpeechStopReason.DENIED_NOT_READY -> "Configure speech recognition in Nexus first."
+        NexusSpeechStopReason.CANCELLED -> "Voice entry cancelled."
+        else -> error?.kind?.takeIf(String::isNotBlank)?.let { "Speech failed: $it" }
+            ?: "Speech recognition failed."
+    }
+
     private fun loadProduct(barcode: String, operationGeneration: Long) {
         store.product(barcode)?.let {
             showProduct(it)
@@ -327,6 +477,7 @@ class FoodLogPluginService : NexusPluginService() {
         val card = when (screen) {
             Screen.HOME -> homeCard()
             Screen.SCANNING -> messageCard(messageTitle, messageLines, "back to cancel")
+            Screen.VOICE -> voiceCard()
             Screen.PRODUCT -> productCard(selectedProduct)
             Screen.PORTION -> portionCard(selectedProduct)
             Screen.TODAY -> todayCard()
@@ -346,7 +497,7 @@ class FoodLogPluginService : NexusPluginService() {
             richLines = HOME_ITEMS.mapIndexed { index, item ->
                 NexusCardLine(
                     text = item.first,
-                    sub = if (index == 1) {
+                    sub = if (index == 2) {
                         "${totals.caloriesKcal.display("kcal")} · P ${totals.proteinGrams.display("g")}"
                     } else {
                         item.second
@@ -358,6 +509,18 @@ class FoodLogPluginService : NexusPluginService() {
             contentKey = "foodlog-home-v1",
         )
     }
+
+    private fun voiceCard(): NexusCard = NexusCard(
+        title = "Add by voice",
+        subtitle = voiceStatus.hud(240),
+        lines = listOf(
+            voiceTranscript().ifBlank { "Say: 200 grams of rice" }.hud(240),
+            "Food names are matched locally against your recent foods.",
+        ),
+        footer = "tap to stop · back to cancel",
+        contentKey = "foodlog-voice",
+        handlesBack = true,
+    )
 
     private fun productCard(product: FoodProduct?): NexusCard {
         if (product == null) return messageCard("Product", listOf("Product unavailable."), "back")
@@ -485,6 +648,7 @@ class FoodLogPluginService : NexusPluginService() {
     private enum class Screen {
         HOME,
         SCANNING,
+        VOICE,
         PRODUCT,
         PORTION,
         TODAY,
@@ -498,8 +662,10 @@ class FoodLogPluginService : NexusPluginService() {
         const val DEFAULT_QUANTITY_GRAMS = 100.0
         const val QUANTITY_STEP_GRAMS = 10.0
         const val MAX_HUD_ENTRIES = 8
+        const val MAX_VOICE_TRANSCRIPT_CHARS = 240
         val HOME_ITEMS = listOf(
             "Scan product" to "EAN or UPC with the glasses camera",
+            "Add by voice" to "Say an amount and a recent food",
             "Today" to "Daily nutrition and entries",
             "Recent foods" to "Log something again",
             "Undo last" to "Exact last entry from today",

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogPluginService.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogPluginService.kt
@@ -18,6 +18,11 @@ import com.anezium.rokidbus.client.plugin.NexusSpeechState
 import com.anezium.rokidbus.client.plugin.NexusSpeechStopReason
 import com.anezium.rokidbus.client.plugin.NexusSurfaceSession
 import com.anezium.rokidbus.shared.plugin.NexusInputEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -26,9 +31,11 @@ import java.util.concurrent.Executors
 class FoodLogPluginService : NexusPluginService() {
     private val mainHandler = Handler(Looper.getMainLooper())
     private val ioExecutor = Executors.newSingleThreadExecutor()
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val store by lazy { FoodLogStore(applicationContext) }
     private val foodFacts = FoodFactsClient()
     private val barcodeScanner by lazy { FoodBarcodeScanner(ioExecutor) }
+    private val healthBridge by lazy { FoodLogHealthConnectBridge(applicationContext) }
 
     private var surface: NexusSurfaceSession? = null
     private var snapshotSession: NexusSnapshotSession? = null
@@ -37,9 +44,14 @@ class FoodLogPluginService : NexusPluginService() {
     private var screen = Screen.HOME
     private var selectedIndex = 0
     private var selectedProduct: FoodProduct? = null
+    private var selectedSource = FoodEntrySource.UNKNOWN
+    private var selectedRecipeId: String? = null
     private var quantityGrams = DEFAULT_QUANTITY_GRAMS
     private var todayEntries: List<FoodEntry> = emptyList()
     private var recentProducts: List<FoodProduct> = emptyList()
+    private var favoriteProducts: List<FoodProduct> = emptyList()
+    private var recipes: List<FoodRecipe> = emptyList()
+    private var goals: NutritionGoals? = null
     private var undoCandidate: FoodEntry? = null
     private var messageTitle = "Food Log"
     private var messageLines = emptyList<String>()
@@ -100,6 +112,8 @@ class FoodLogPluginService : NexusPluginService() {
         screen = Screen.HOME
         selectedIndex = 0
         selectedProduct = null
+        selectedSource = FoodEntrySource.UNKNOWN
+        selectedRecipeId = null
         undoCandidate = null
         clearVoice()
         refreshLocalState()
@@ -117,6 +131,8 @@ class FoodLogPluginService : NexusPluginService() {
         surface?.hide()
         surface = null
         selectedProduct = null
+        selectedSource = FoodEntrySource.UNKNOWN
+        selectedRecipeId = null
         undoCandidate = null
         screen = Screen.HOME
         clearVoice()
@@ -130,6 +146,7 @@ class FoodLogPluginService : NexusPluginService() {
         speechSession?.stop()
         speechSession = null
         barcodeScanner.close()
+        serviceScope.cancel()
         ioExecutor.shutdownNow()
         store.close()
         super.onDestroy()
@@ -161,6 +178,14 @@ class FoodLogPluginService : NexusPluginService() {
                 selectedIndex = Math.floorMod(selectedIndex + delta, recentProducts.size)
                 render(show = false)
             }
+            Screen.FAVORITES -> if (favoriteProducts.isNotEmpty()) {
+                selectedIndex = Math.floorMod(selectedIndex + delta, favoriteProducts.size)
+                render(show = false)
+            }
+            Screen.RECIPES -> if (recipes.isNotEmpty()) {
+                selectedIndex = Math.floorMod(selectedIndex + delta, recipes.size)
+                render(show = false)
+            }
             Screen.PORTION -> {
                 quantityGrams = (quantityGrams + delta * QUANTITY_STEP_GRAMS)
                     .coerceIn(MIN_QUANTITY_GRAMS, MAX_QUANTITY_GRAMS)
@@ -176,15 +201,25 @@ class FoodLogPluginService : NexusPluginService() {
                 0 -> startSnapshot()
                 1 -> startVoiceEntry()
                 2 -> showToday()
-                3 -> showRecents()
-                4 -> confirmUndo()
+                3 -> showFavorites()
+                4 -> showRecipes()
+                5 -> showRecents()
+                6 -> confirmUndo()
             }
             Screen.PRODUCT -> {
                 screen = Screen.PORTION
                 render(show = false)
             }
             Screen.PORTION -> addSelectedProduct()
-            Screen.RECENTS -> recentProducts.getOrNull(selectedIndex)?.let(::showProduct)
+            Screen.RECENTS -> recentProducts.getOrNull(selectedIndex)?.let { product ->
+                showProduct(product, sourceFor(product))
+            }
+            Screen.FAVORITES -> favoriteProducts.getOrNull(selectedIndex)?.let { product ->
+                showProduct(product, sourceFor(product))
+            }
+            Screen.RECIPES -> recipes.getOrNull(selectedIndex)?.let { recipe ->
+                showProduct(recipe.asProduct(), FoodEntrySource.RECIPE, recipe.uuid)
+            }
             Screen.CONFIRM_UNDO -> deleteUndoCandidate()
             Screen.VOICE -> {
                 stopVoiceWhenStarted = true
@@ -216,6 +251,8 @@ class FoodLogPluginService : NexusPluginService() {
         screen = Screen.HOME
         selectedIndex = 0
         selectedProduct = null
+        selectedSource = FoodEntrySource.UNKNOWN
+        selectedRecipeId = null
         undoCandidate = null
         clearVoice()
         render(show = false)
@@ -238,6 +275,28 @@ class FoodLogPluginService : NexusPluginService() {
         render(show = false)
     }
 
+    private fun showFavorites() {
+        refreshLocalState()
+        if (favoriteProducts.isEmpty()) {
+            showMessage("Favorites", "Add favorites from Food Log on the phone.")
+            return
+        }
+        selectedIndex = 0
+        screen = Screen.FAVORITES
+        render(show = false)
+    }
+
+    private fun showRecipes() {
+        refreshLocalState()
+        if (recipes.isEmpty()) {
+            showMessage("Recipes", "Create a recipe from Food Log on the phone.")
+            return
+        }
+        selectedIndex = 0
+        screen = Screen.RECIPES
+        render(show = false)
+    }
+
     private fun confirmUndo() {
         val candidate = store.latestEntryForDay()
         if (candidate == null) {
@@ -252,6 +311,7 @@ class FoodLogPluginService : NexusPluginService() {
     private fun deleteUndoCandidate() {
         val candidate = undoCandidate ?: return showHome()
         val removed = store.deleteEntry(candidate.id)
+        if (removed) deleteHealthEntryIfEnabled(candidate)
         undoCandidate = null
         refreshLocalState()
         showMessage(
@@ -357,6 +417,9 @@ class FoodLogPluginService : NexusPluginService() {
         when (val match = FoodVoiceParser.match(voiceTranscript(), recentProducts)) {
             is FoodVoiceMatch.Matched -> {
                 selectedProduct = match.product
+                selectedSource = sourceFor(match.product)
+                selectedRecipeId = match.product.barcode.removePrefix("recipe-")
+                    .takeIf { match.product.barcode.startsWith("recipe-") }
                 quantityGrams = match.quantityGrams
                 screen = Screen.PORTION
                 render(show = false)
@@ -404,7 +467,7 @@ class FoodLogPluginService : NexusPluginService() {
 
     private fun loadProduct(barcode: String, operationGeneration: Long) {
         store.product(barcode)?.let {
-            showProduct(it)
+            showProduct(it, FoodEntrySource.SCANNED)
             return
         }
         messageTitle = "Open Food Facts"
@@ -423,7 +486,7 @@ class FoodLogPluginService : NexusPluginService() {
                                 "Add it manually from Food Log settings on the phone.",
                             )
                         } else {
-                            showProduct(product)
+                            showProduct(product, FoodEntrySource.SCANNED)
                         }
                     },
                     onFailure = {
@@ -437,8 +500,14 @@ class FoodLogPluginService : NexusPluginService() {
         }
     }
 
-    private fun showProduct(product: FoodProduct) {
+    private fun showProduct(
+        product: FoodProduct,
+        source: FoodEntrySource,
+        recipeId: String? = null,
+    ) {
         selectedProduct = product
+        selectedSource = source
+        selectedRecipeId = recipeId
         quantityGrams = product.servingGrams
             ?.takeIf { it in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS }
             ?: DEFAULT_QUANTITY_GRAMS
@@ -448,7 +517,16 @@ class FoodLogPluginService : NexusPluginService() {
 
     private fun addSelectedProduct() {
         val product = selectedProduct ?: return showHome()
-        store.addEntry(product, quantityGrams)
+        val consumedAt = System.currentTimeMillis()
+        val entryId = store.addEntry(
+            product = product,
+            quantityGrams = quantityGrams,
+            consumedAtMillis = consumedAt,
+            mealType = inferredMealType(consumedAt),
+            source = selectedSource,
+            recipeId = selectedRecipeId,
+        )
+        val entry = store.entry(entryId)
         refreshLocalState()
         val totals = aggregateNutrition(todayEntries)
         showMessage(
@@ -456,6 +534,7 @@ class FoodLogPluginService : NexusPluginService() {
             "${product.name} · ${formatNutritionNumber(quantityGrams)} g",
             "Today: ${totals.caloriesKcal.display("kcal")}",
         )
+        entry?.let(::syncEntryIfEnabled)
     }
 
     private fun showMessage(title: String, vararg lines: String) {
@@ -468,6 +547,36 @@ class FoodLogPluginService : NexusPluginService() {
     private fun refreshLocalState() {
         todayEntries = store.entriesForDay()
         recentProducts = store.recentProducts()
+        favoriteProducts = store.favoriteProducts()
+        recipes = store.recipes()
+        goals = store.goals()
+    }
+
+    private fun syncEntryIfEnabled(entry: FoodEntry) {
+        val enabled = getSharedPreferences(FOOD_LOG_PREFERENCES, MODE_PRIVATE)
+            .getBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false)
+        if (!enabled) return
+        serviceScope.launch {
+            when (healthBridge.syncEntry(entry, userOptedIn = true)) {
+                FoodLogHealthConnectSyncResult.PermissionRequired -> {
+                    getSharedPreferences(FOOD_LOG_PREFERENCES, MODE_PRIVATE)
+                        .edit()
+                        .putBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false)
+                        .apply()
+                }
+                else -> Unit
+            }
+        }
+    }
+
+    private fun deleteHealthEntryIfEnabled(entry: FoodEntry) {
+        val preferences = getSharedPreferences(FOOD_LOG_PREFERENCES, MODE_PRIVATE)
+        if (!preferences.getBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false)) return
+        serviceScope.launch {
+            if (healthBridge.deleteEntry(entry, userOptedIn = true) == FoodLogHealthConnectSyncResult.PermissionRequired) {
+                preferences.edit().putBoolean(FOOD_LOG_HEALTH_SYNC_KEY, false).apply()
+            }
+        }
     }
 
     private fun isCurrent(operationGeneration: Long): Boolean =
@@ -482,6 +591,8 @@ class FoodLogPluginService : NexusPluginService() {
             Screen.PORTION -> portionCard(selectedProduct)
             Screen.TODAY -> todayCard()
             Screen.RECENTS -> recentsCard()
+            Screen.FAVORITES -> productListCard("Favorites", favoriteProducts, "foodlog-favorites")
+            Screen.RECIPES -> recipeListCard()
             Screen.CONFIRM_UNDO -> undoCard(undoCandidate)
             Screen.MESSAGE -> messageCard(messageTitle, messageLines, "tap or back")
         }
@@ -498,7 +609,10 @@ class FoodLogPluginService : NexusPluginService() {
                 NexusCardLine(
                     text = item.first,
                     sub = if (index == 2) {
-                        "${totals.caloriesKcal.display("kcal")} · P ${totals.proteinGrams.display("g")}"
+                        buildString {
+                            append("${totals.caloriesKcal.display("kcal")} · P ${totals.proteinGrams.display("g")}")
+                            goals?.caloriesKcal?.let { append(" · goal ${formatNutritionNumber(it)}") }
+                        }
                     } else {
                         item.second
                     },
@@ -615,6 +729,36 @@ class FoodLogPluginService : NexusPluginService() {
         handlesBack = true,
     )
 
+    private fun productListCard(title: String, products: List<FoodProduct>, key: String): NexusCard = NexusCard(
+        title = title,
+        lines = emptyList(),
+        richLines = products.mapIndexed { index, product ->
+            NexusCardLine(
+                text = product.name.hud(240),
+                sub = product.brand.hud(240).ifBlank { product.barcode },
+                selected = index == selectedIndex,
+            )
+        },
+        footer = "swipe · tap · back",
+        contentKey = key,
+        handlesBack = true,
+    )
+
+    private fun recipeListCard(): NexusCard = NexusCard(
+        title = "Recipes",
+        lines = emptyList(),
+        richLines = recipes.mapIndexed { index, recipe ->
+            NexusCardLine(
+                text = recipe.name.hud(240),
+                sub = "${recipe.ingredients.size} ingredients · ${formatNutritionNumber(recipe.servings)} servings",
+                selected = index == selectedIndex,
+            )
+        },
+        footer = "swipe · tap · back",
+        contentKey = "foodlog-recipes",
+        handlesBack = true,
+    )
+
     private fun undoCard(entry: FoodEntry?): NexusCard {
         if (entry == null) return messageCard("Undo last", listOf("Nothing to remove."), "back")
         return NexusCard(
@@ -653,6 +797,8 @@ class FoodLogPluginService : NexusPluginService() {
         PORTION,
         TODAY,
         RECENTS,
+        FAVORITES,
+        RECIPES,
         CONFIRM_UNDO,
         MESSAGE,
     }
@@ -667,10 +813,18 @@ class FoodLogPluginService : NexusPluginService() {
             "Scan product" to "EAN or UPC with the glasses camera",
             "Add by voice" to "Say an amount and a recent food",
             "Today" to "Daily nutrition and entries",
+            "Favorites" to "Foods saved on the phone",
+            "Recipes" to "Log one saved serving",
             "Recent foods" to "Log something again",
             "Undo last" to "Exact last entry from today",
         )
     }
+}
+
+private fun sourceFor(product: FoodProduct): FoodEntrySource = when {
+    product.barcode.startsWith("custom-") -> FoodEntrySource.CUSTOM
+    product.barcode.startsWith("recipe-") -> FoodEntrySource.RECIPE
+    else -> FoodEntrySource.SEARCHED
 }
 
 private fun String.hud(limit: Int): String = trim().take(limit)

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogPluginService.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogPluginService.kt
@@ -1,0 +1,515 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import android.os.Handler
+import android.os.Looper
+import android.view.KeyEvent
+import com.anezium.rokidbus.client.plugin.NexusCard
+import com.anezium.rokidbus.client.plugin.NexusCardLine
+import com.anezium.rokidbus.client.plugin.NexusPluginService
+import com.anezium.rokidbus.client.plugin.NexusRowTone
+import com.anezium.rokidbus.client.plugin.NexusSdkResult
+import com.anezium.rokidbus.client.plugin.NexusSnapshotCallbacks
+import com.anezium.rokidbus.client.plugin.NexusSnapshotError
+import com.anezium.rokidbus.client.plugin.NexusSnapshotSession
+import com.anezium.rokidbus.client.plugin.NexusSurfaceSession
+import com.anezium.rokidbus.shared.plugin.NexusInputEvent
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.Executors
+
+class FoodLogPluginService : NexusPluginService() {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val ioExecutor = Executors.newSingleThreadExecutor()
+    private val store by lazy { FoodLogStore(applicationContext) }
+    private val foodFacts = FoodFactsClient()
+    private val barcodeScanner by lazy { FoodBarcodeScanner(ioExecutor) }
+
+    private var surface: NexusSurfaceSession? = null
+    private var snapshotSession: NexusSnapshotSession? = null
+    private var generation = 0L
+    private var screen = Screen.HOME
+    private var selectedIndex = 0
+    private var selectedProduct: FoodProduct? = null
+    private var quantityGrams = DEFAULT_QUANTITY_GRAMS
+    private var todayEntries: List<FoodEntry> = emptyList()
+    private var recentProducts: List<FoodProduct> = emptyList()
+    private var undoCandidate: FoodEntry? = null
+    private var messageTitle = "Food Log"
+    private var messageLines = emptyList<String>()
+
+    override fun onNexusOpen() {
+        generation += 1
+        screen = Screen.HOME
+        selectedIndex = 0
+        selectedProduct = null
+        undoCandidate = null
+        refreshLocalState()
+        surface = nexusSurfaceSession(SURFACE_ID)
+        render(show = true)
+    }
+
+    override fun onNexusClose() {
+        generation += 1
+        snapshotSession?.cancel()
+        snapshotSession = null
+        surface?.hide()
+        surface = null
+        selectedProduct = null
+        undoCandidate = null
+        screen = Screen.HOME
+    }
+
+    override fun onDestroy() {
+        generation += 1
+        snapshotSession?.cancel()
+        snapshotSession = null
+        barcodeScanner.close()
+        ioExecutor.shutdownNow()
+        store.close()
+        super.onDestroy()
+    }
+
+    override fun onNexusInput(event: NexusInputEvent) {
+        if (event.action != KeyEvent.ACTION_DOWN) return
+        when (event.keyCode) {
+            KeyEvent.KEYCODE_DPAD_RIGHT,
+            KeyEvent.KEYCODE_DPAD_DOWN,
+            -> move(1)
+            KeyEvent.KEYCODE_DPAD_LEFT,
+            KeyEvent.KEYCODE_DPAD_UP,
+            -> move(-1)
+            KeyEvent.KEYCODE_DPAD_CENTER,
+            KeyEvent.KEYCODE_ENTER,
+            -> activate()
+            KeyEvent.KEYCODE_BACK -> back()
+        }
+    }
+
+    private fun move(delta: Int) {
+        when (screen) {
+            Screen.HOME -> {
+                selectedIndex = Math.floorMod(selectedIndex + delta, HOME_ITEMS.size)
+                render(show = false)
+            }
+            Screen.RECENTS -> if (recentProducts.isNotEmpty()) {
+                selectedIndex = Math.floorMod(selectedIndex + delta, recentProducts.size)
+                render(show = false)
+            }
+            Screen.PORTION -> {
+                quantityGrams = (quantityGrams + delta * QUANTITY_STEP_GRAMS)
+                    .coerceIn(MIN_QUANTITY_GRAMS, MAX_QUANTITY_GRAMS)
+                render(show = false)
+            }
+            else -> Unit
+        }
+    }
+
+    private fun activate() {
+        when (screen) {
+            Screen.HOME -> when (selectedIndex) {
+                0 -> startSnapshot()
+                1 -> showToday()
+                2 -> showRecents()
+                3 -> confirmUndo()
+            }
+            Screen.PRODUCT -> {
+                screen = Screen.PORTION
+                render(show = false)
+            }
+            Screen.PORTION -> addSelectedProduct()
+            Screen.RECENTS -> recentProducts.getOrNull(selectedIndex)?.let(::showProduct)
+            Screen.CONFIRM_UNDO -> deleteUndoCandidate()
+            Screen.MESSAGE -> showHome()
+            Screen.TODAY,
+            Screen.SCANNING,
+            -> Unit
+        }
+    }
+
+    private fun back() {
+        if (screen == Screen.HOME) {
+            surface?.hide()
+            return
+        }
+        generation += 1
+        snapshotSession?.cancel()
+        snapshotSession = null
+        showHome()
+    }
+
+    private fun showHome() {
+        refreshLocalState()
+        screen = Screen.HOME
+        selectedIndex = 0
+        selectedProduct = null
+        undoCandidate = null
+        render(show = false)
+    }
+
+    private fun showToday() {
+        refreshLocalState()
+        screen = Screen.TODAY
+        render(show = false)
+    }
+
+    private fun showRecents() {
+        refreshLocalState()
+        if (recentProducts.isEmpty()) {
+            showMessage("Recent foods", "Nothing logged yet.")
+            return
+        }
+        selectedIndex = 0
+        screen = Screen.RECENTS
+        render(show = false)
+    }
+
+    private fun confirmUndo() {
+        val candidate = store.latestEntryForDay()
+        if (candidate == null) {
+            showMessage("Undo last", "Nothing logged today.")
+            return
+        }
+        undoCandidate = candidate
+        screen = Screen.CONFIRM_UNDO
+        render(show = false)
+    }
+
+    private fun deleteUndoCandidate() {
+        val candidate = undoCandidate ?: return showHome()
+        val removed = store.deleteEntry(candidate.id)
+        undoCandidate = null
+        refreshLocalState()
+        showMessage(
+            "Undo last",
+            if (removed) "Removed ${candidate.product.name}." else "That entry no longer exists.",
+        )
+    }
+
+    private fun startSnapshot() {
+        generation += 1
+        val operationGeneration = generation
+        screen = Screen.SCANNING
+        messageTitle = "Scan barcode"
+        messageLines = listOf("Point at one EAN or UPC barcode.", "Hold still while the photo is taken.")
+        render(show = false)
+        val callbacks = object : NexusSnapshotCallbacks {
+            override fun onSnapshotCaptured(jpeg: ByteArray) {
+                snapshotSession = null
+                if (!isCurrent(operationGeneration)) return
+                messageLines = listOf("Reading barcode…")
+                render(show = false)
+                barcodeScanner.scan(jpeg) { result ->
+                    mainHandler.post {
+                        if (!isCurrent(operationGeneration)) return@post
+                        when (result) {
+                            is FoodBarcodeScanner.Result.Found -> loadProduct(result.code, operationGeneration)
+                            FoodBarcodeScanner.Result.NotFound -> showMessage(
+                                "No barcode found",
+                                "Move closer, keep the label sharp, then try again.",
+                            )
+                            is FoodBarcodeScanner.Result.Ambiguous -> showMessage(
+                                "Several barcodes found",
+                                "Frame a single product and try again.",
+                            )
+                            is FoodBarcodeScanner.Result.Failure -> showMessage(
+                                "Scan failed",
+                                "The image could not be read. Try again.",
+                            )
+                        }
+                    }
+                }
+            }
+
+            override fun onSnapshotError(error: NexusSnapshotError) {
+                snapshotSession = null
+                if (!isCurrent(operationGeneration)) return
+                val message = when (error) {
+                    NexusSnapshotError.BUSY -> "The glasses camera is busy."
+                    NexusSnapshotError.LINK_DOWN -> "The glasses link is unavailable."
+                    NexusSnapshotError.TIMEOUT -> "The camera did not answer in time."
+                    NexusSnapshotError.CANCELLED -> "Capture cancelled."
+                    NexusSnapshotError.CAPTURE_FAILED,
+                    NexusSnapshotError.ERROR,
+                    -> "The photo could not be captured."
+                }
+                showMessage("Scan unavailable", message)
+            }
+        }
+        val session = nexusSnapshotSession(callbacks)
+        snapshotSession = session
+        val result = session?.capture()
+        if (result != NexusSdkResult.SENT) {
+            snapshotSession = null
+            session?.cancel()
+            val message = when (result) {
+                NexusSdkResult.CAPABILITY_NOT_GRANTED ->
+                    "Grant Glasses camera access to Food Log in Nexus settings."
+                NexusSdkResult.CAPABILITY_NOT_AVAILABLE -> "Camera snapshots are not supported by this hub."
+                else -> "The glasses camera is not ready."
+            }
+            showMessage("Scan unavailable", message)
+        }
+    }
+
+    private fun loadProduct(barcode: String, operationGeneration: Long) {
+        store.product(barcode)?.let {
+            showProduct(it)
+            return
+        }
+        messageTitle = "Open Food Facts"
+        messageLines = listOf("Looking up product…")
+        render(show = false)
+        ioExecutor.execute {
+            val result = runCatching { foodFacts.product(barcode) }
+            result.getOrNull()?.let(store::upsertProduct)
+            mainHandler.post {
+                if (!isCurrent(operationGeneration)) return@post
+                result.fold(
+                    onSuccess = { product ->
+                        if (product == null) {
+                            showMessage(
+                                "Product not found",
+                                "Add it manually from Food Log settings on the phone.",
+                            )
+                        } else {
+                            showProduct(product)
+                        }
+                    },
+                    onFailure = {
+                        showMessage(
+                            "Lookup failed",
+                            "Check the phone network connection and try again.",
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    private fun showProduct(product: FoodProduct) {
+        selectedProduct = product
+        quantityGrams = product.servingGrams
+            ?.takeIf { it in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS }
+            ?: DEFAULT_QUANTITY_GRAMS
+        screen = Screen.PRODUCT
+        render(show = false)
+    }
+
+    private fun addSelectedProduct() {
+        val product = selectedProduct ?: return showHome()
+        store.addEntry(product, quantityGrams)
+        refreshLocalState()
+        val totals = aggregateNutrition(todayEntries)
+        showMessage(
+            "Added",
+            "${product.name} · ${formatNutritionNumber(quantityGrams)} g",
+            "Today: ${totals.caloriesKcal.display("kcal")}",
+        )
+    }
+
+    private fun showMessage(title: String, vararg lines: String) {
+        messageTitle = title
+        messageLines = lines.toList()
+        screen = Screen.MESSAGE
+        render(show = false)
+    }
+
+    private fun refreshLocalState() {
+        todayEntries = store.entriesForDay()
+        recentProducts = store.recentProducts()
+    }
+
+    private fun isCurrent(operationGeneration: Long): Boolean =
+        operationGeneration == generation && isNexusSessionOpen
+
+    private fun render(show: Boolean) {
+        val card = when (screen) {
+            Screen.HOME -> homeCard()
+            Screen.SCANNING -> messageCard(messageTitle, messageLines, "back to cancel")
+            Screen.PRODUCT -> productCard(selectedProduct)
+            Screen.PORTION -> portionCard(selectedProduct)
+            Screen.TODAY -> todayCard()
+            Screen.RECENTS -> recentsCard()
+            Screen.CONFIRM_UNDO -> undoCard(undoCandidate)
+            Screen.MESSAGE -> messageCard(messageTitle, messageLines, "tap or back")
+        }
+        if (show) surface?.showCard(card) else surface?.updateCard(card)
+    }
+
+    private fun homeCard(): NexusCard {
+        val totals = aggregateNutrition(todayEntries)
+        return NexusCard(
+            title = "Food Log",
+            subtitle = "Today · ${totals.entryCount} ${if (totals.entryCount == 1) "entry" else "entries"}",
+            lines = emptyList(),
+            richLines = HOME_ITEMS.mapIndexed { index, item ->
+                NexusCardLine(
+                    text = item.first,
+                    sub = if (index == 1) {
+                        "${totals.caloriesKcal.display("kcal")} · P ${totals.proteinGrams.display("g")}"
+                    } else {
+                        item.second
+                    },
+                    selected = index == selectedIndex,
+                )
+            },
+            footer = "swipe · tap · back",
+            contentKey = "foodlog-home-v1",
+        )
+    }
+
+    private fun productCard(product: FoodProduct?): NexusCard {
+        if (product == null) return messageCard("Product", listOf("Product unavailable."), "back")
+        val nutrients = product.nutrients
+        return NexusCard(
+            title = product.name.hud(120),
+            subtitle = product.brand.hud(240).ifBlank { "Open Food Facts" },
+            lines = listOf(
+                "Energy · ${nutrients.caloriesKcal.displayPer100g("kcal / 100 g")}",
+                "Protein · ${nutrients.proteinGrams.displayPer100g("g / 100 g")}",
+                "Carbs · ${nutrients.carbohydrateGrams.displayPer100g("g / 100 g")}",
+                "Fat · ${nutrients.fatGrams.displayPer100g("g / 100 g")}",
+                productBadges(product),
+            ),
+            footer = "tap to choose amount · back",
+            contentKey = "foodlog-product",
+            handlesBack = true,
+        )
+    }
+
+    private fun portionCard(product: FoodProduct?): NexusCard {
+        if (product == null) return messageCard("Amount", listOf("Product unavailable."), "back")
+        val calories = scaledValue(product.nutrients.caloriesKcal, quantityGrams)
+        return NexusCard(
+            title = "How much?",
+            subtitle = product.name.hud(240),
+            lines = emptyList(),
+            richLines = listOf(
+                NexusCardLine(
+                    text = "${formatNutritionNumber(quantityGrams)} g",
+                    sub = calories?.let { "${formatNutritionNumber(it)} kcal" }
+                        ?: "Energy unknown",
+                    tone = NexusRowTone.ALERT,
+                    selected = true,
+                ),
+            ),
+            footer = "swipe ±10 g · tap to add · back",
+            contentKey = "foodlog-portion",
+            handlesBack = true,
+        )
+    }
+
+    private fun todayCard(): NexusCard {
+        val totals = aggregateNutrition(todayEntries)
+        val rows = buildList {
+            add(
+                NexusCardLine(
+                    text = totals.caloriesKcal.display("kcal"),
+                    sub = "P ${totals.proteinGrams.display("g")} · C ${totals.carbohydrateGrams.display("g")} · F ${totals.fatGrams.display("g")}",
+                    tone = NexusRowTone.ALERT,
+                ),
+            )
+            todayEntries.take(MAX_HUD_ENTRIES).forEach { entry ->
+                val calories = scaledValue(entry.product.nutrients.caloriesKcal, entry.quantityGrams)
+                add(
+                    NexusCardLine(
+                        text = entry.product.name.hud(240),
+                        badge = "${formatNutritionNumber(entry.quantityGrams)}g".hud(24),
+                        sub = "${entry.consumedTime()} · ${calories?.let(::formatNutritionNumber) ?: "?"} kcal",
+                    ),
+                )
+            }
+            if (todayEntries.isEmpty()) {
+                add(NexusCardLine("Nothing logged today.", tone = NexusRowTone.DIM))
+            } else if (todayEntries.size > MAX_HUD_ENTRIES) {
+                add(NexusCardLine("${todayEntries.size - MAX_HUD_ENTRIES} more on phone", tone = NexusRowTone.DIM))
+            }
+        }
+        return NexusCard(
+            title = "Today",
+            subtitle = "${todayEntries.size} ${if (todayEntries.size == 1) "entry" else "entries"}",
+            lines = emptyList(),
+            richLines = rows,
+            footer = "back",
+            contentKey = "foodlog-today",
+            handlesBack = true,
+        )
+    }
+
+    private fun recentsCard(): NexusCard = NexusCard(
+        title = "Recent foods",
+        lines = emptyList(),
+        richLines = recentProducts.mapIndexed { index, product ->
+            NexusCardLine(
+                text = product.name.hud(240),
+                sub = product.brand.hud(240).ifBlank { product.barcode },
+                selected = index == selectedIndex,
+            )
+        },
+        footer = "swipe · tap · back",
+        contentKey = "foodlog-recents",
+        handlesBack = true,
+    )
+
+    private fun undoCard(entry: FoodEntry?): NexusCard {
+        if (entry == null) return messageCard("Undo last", listOf("Nothing to remove."), "back")
+        return NexusCard(
+            title = "Remove last entry?",
+            subtitle = entry.consumedTime(),
+            lines = listOf(
+                entry.product.name.hud(240),
+                "${formatNutritionNumber(entry.quantityGrams)} g",
+                "This removes exactly this log entry.",
+            ),
+            footer = "tap to remove · back to keep",
+            contentKey = "foodlog-undo",
+            handlesBack = true,
+        )
+    }
+
+    private fun messageCard(title: String, lines: List<String>, footer: String): NexusCard = NexusCard(
+        title = title.hud(120),
+        lines = lines.map { it.hud(240) },
+        footer = footer,
+        contentKey = "foodlog-message",
+        handlesBack = true,
+    )
+
+    private fun productBadges(product: FoodProduct): String = buildList {
+        product.nutritionGrade?.uppercase()?.let { add("Nutri-Score $it") }
+        product.novaGroup?.let { add("NOVA $it") }
+        if (isEmpty()) add("Community data may be incomplete")
+    }.joinToString(" · ").hud(240)
+
+    private enum class Screen {
+        HOME,
+        SCANNING,
+        PRODUCT,
+        PORTION,
+        TODAY,
+        RECENTS,
+        CONFIRM_UNDO,
+        MESSAGE,
+    }
+
+    private companion object {
+        const val SURFACE_ID = "foodlog-main"
+        const val DEFAULT_QUANTITY_GRAMS = 100.0
+        const val QUANTITY_STEP_GRAMS = 10.0
+        const val MAX_HUD_ENTRIES = 8
+        val HOME_ITEMS = listOf(
+            "Scan product" to "EAN or UPC with the glasses camera",
+            "Today" to "Daily nutrition and entries",
+            "Recent foods" to "Log something again",
+            "Undo last" to "Exact last entry from today",
+        )
+    }
+}
+
+private fun String.hud(limit: Int): String = trim().take(limit)
+
+private fun FoodEntry.consumedTime(): String =
+    Instant.ofEpochMilli(consumedAtMillis)
+        .atZone(ZoneId.systemDefault())
+        .format(DateTimeFormatter.ofPattern("HH:mm"))

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderDelivery.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderDelivery.kt
@@ -1,0 +1,119 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import com.anezium.rokidbus.client.PluginRegistrationResult
+import com.anezium.rokidbus.client.plugin.NexusNotice
+import com.anezium.rokidbus.client.plugin.NexusPin
+import com.anezium.rokidbus.client.plugin.NexusPluginCallbacks
+import com.anezium.rokidbus.client.plugin.NexusPluginClient
+import com.anezium.rokidbus.client.plugin.NexusSdkResult
+import com.anezium.rokidbus.shared.LinkStateBits
+import com.anezium.rokidbus.shared.plugin.NexusInputEvent
+import org.json.JSONObject
+import java.util.concurrent.Executors
+
+/** Only starts delivery for a receiver-authenticated alarm. Boot work is rescheduling only. */
+class FoodLogReminderReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == FoodLogReminderContract.ACTION_FIRE) {
+            intent.getStringExtra(FoodLogReminderContract.EXTRA_ID)?.let { FoodLogReminderDeliveryService.start(context, it, false) }
+            return
+        }
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED && intent.action != Intent.ACTION_MY_PACKAGE_REPLACED) return
+        val result = goAsync()
+        EXECUTOR.execute {
+            try {
+                val scheduler = foodLogReminderScheduler(context)
+                FoodLogReminderStore(context).all().filter(FoodLogReminder::enabled).forEach { scheduler.reschedule(it) }
+            } finally { result.finish() }
+        }
+    }
+    private companion object { val EXECUTOR = Executors.newSingleThreadExecutor() }
+}
+
+class FoodLogReminderDeliveryService : Service() {
+    private val worker = Executors.newSingleThreadExecutor()
+    private val main = Handler(Looper.getMainLooper())
+    private val notifications by lazy { getSystemService(NotificationManager::class.java) }
+
+    override fun onCreate() { super.onCreate(); createChannels() }
+    override fun onBind(intent: Intent?): IBinder? = null
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        beginForeground()
+        val id = intent?.getStringExtra(FoodLogReminderContract.EXTRA_ID)
+        if (id == null) { finish(startId); return START_NOT_STICKY }
+        val late = intent.getBooleanExtra(FoodLogReminderContract.EXTRA_LATE, false)
+        worker.execute {
+            try {
+                val reminder = FoodLogReminderStore(applicationContext).takeForDelivery(id) ?: return@execute
+                postNotification(reminder, late)
+                main.post { OneShotFoodLogGlassesDelivery(applicationContext).deliver(reminder, late) }
+            } finally {
+                // The glasses handshake is bounded independently and cannot keep this service alive.
+                main.postDelayed({ finish(startId) }, DELIVERY_LIFETIME_MS)
+            }
+        }
+        return START_NOT_STICKY
+    }
+    override fun onDestroy() { worker.shutdownNow(); super.onDestroy() }
+
+    private fun beginForeground() {
+        val notification = Notification.Builder(this, DELIVERY_CHANNEL).setSmallIcon(R.drawable.nexus_glyph_foodlog)
+            .setContentTitle("Food Log reminder").setContentText("Delivering reminder").setOngoing(true).setCategory(Notification.CATEGORY_SERVICE).build()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) startForeground(DELIVERY_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE) else startForeground(DELIVERY_ID, notification)
+    }
+    private fun postNotification(value: FoodLogReminder, late: Boolean) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) return
+        val title = when (value.kind) { FoodLogReminderKind.MEAL -> "Meal reminder"; FoodLogReminderKind.HYDRATION -> "Hydration reminder" } + if (late) " (late)" else ""
+        notifications.notify(value.id.hashCode(), Notification.Builder(this, REMINDER_CHANNEL).setSmallIcon(R.drawable.nexus_glyph_foodlog).setContentTitle(title).setContentText(value.label).setStyle(Notification.BigTextStyle().bigText(value.label)).setAutoCancel(true).setCategory(Notification.CATEGORY_REMINDER).build())
+    }
+    private fun createChannels() {
+        notifications.createNotificationChannel(NotificationChannel(REMINDER_CHANNEL, "Food Log reminders", NotificationManager.IMPORTANCE_HIGH))
+        notifications.createNotificationChannel(NotificationChannel(DELIVERY_CHANNEL, "Food Log reminder delivery", NotificationManager.IMPORTANCE_LOW).apply { setShowBadge(false) })
+    }
+    private fun finish(startId: Int) { if (stopSelfResult(startId)) stopForeground(STOP_FOREGROUND_REMOVE) }
+    private companion object {
+        const val REMINDER_CHANNEL = "food_log_reminders"; const val DELIVERY_CHANNEL = "food_log_reminder_delivery"; const val DELIVERY_ID = 0x464c; const val DELIVERY_LIFETIME_MS = 8_000L
+        fun start(context: Context, id: String, late: Boolean) = context.startForegroundService(Intent(context, FoodLogReminderDeliveryService::class.java).putExtra(FoodLogReminderContract.EXTRA_ID, id).putExtra(FoodLogReminderContract.EXTRA_LATE, late))
+    }
+}
+
+/** A single short connection; it never retries and is released after one attempted notice or pin. */
+private class OneShotFoodLogGlassesDelivery(private val context: Context) : NexusPluginCallbacks {
+    private var client: NexusPluginClient? = null
+    private var value: FoodLogReminder? = null
+    private var late = false
+    private var approved = false
+    private var linkState: Int? = null
+    private val timeout = Handler(Looper.getMainLooper())
+    fun deliver(reminder: FoodLogReminder, late: Boolean) {
+        value = reminder; this.late = late
+        client = NexusPluginClient.create(context, "foodlog", this).also { it.connect() }
+        timeout.postDelayed(::close, 5_000L)
+    }
+    override fun onOpen() = Unit; override fun onClose() = close(); override fun onInput(event: NexusInputEvent) = Unit; override fun onMessage(path: String, id: String, payload: JSONObject) = Unit
+    override fun onRegistrationState(result: Int) { approved = result == PluginRegistrationResult.APPROVED; if (!approved && result != PluginRegistrationResult.PENDING_USER_APPROVAL) close() else tryDeliver() }
+    override fun onLinkState(state: Int) { linkState = state; tryDeliver() }
+    private fun tryDeliver() {
+        val current = client ?: return; val state = linkState ?: return; val reminder = value ?: return
+        if (!approved) return
+        val title = when (reminder.kind) { FoodLogReminderKind.MEAL -> "Meal"; FoodLogReminderKind.HYDRATION -> "Hydration" } + if (late) " (late)" else ""
+        if (state and LinkStateBits.SPP_DATA_UP != 0 && current.supportsNoticeSurface) current.showNotice(NexusNotice(title, reminder.label, ttlMs = 20_000L, wakeDisplay = true))
+        else if (current.supportsPinSurface) current.showPin(NexusPin(title.take(24), listOf(reminder.label.take(28))))
+        close()
+    }
+    private fun close() { timeout.removeCallbacksAndMessages(null); client?.close(); client = null; value = null }
+}

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderDelivery.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderDelivery.kt
@@ -29,19 +29,30 @@ import java.util.concurrent.Executors
 class FoodLogReminderReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == FoodLogReminderContract.ACTION_FIRE) {
-            intent.getStringExtra(FoodLogReminderContract.EXTRA_ID)?.let { FoodLogReminderDeliveryService.start(context, it, false) }
+            intent.getStringExtra(FoodLogReminderContract.EXTRA_ID)?.let {
+                FoodLogReminderDeliveryService.start(
+                    context,
+                    it,
+                    intent.getBooleanExtra(FoodLogReminderContract.EXTRA_LATE, false),
+                )
+            }
             return
         }
         if (intent.action != Intent.ACTION_BOOT_COMPLETED && intent.action != Intent.ACTION_MY_PACKAGE_REPLACED) return
         val result = goAsync()
-        EXECUTOR.execute {
+        val executor = Executors.newSingleThreadExecutor()
+        executor.execute {
             try {
                 val scheduler = foodLogReminderScheduler(context)
-                FoodLogReminderStore(context).all().filter(FoodLogReminder::enabled).forEach { scheduler.reschedule(it) }
-            } finally { result.finish() }
+                FoodLogReminderStore(context).all().filter(FoodLogReminder::enabled).forEach {
+                    runCatching { scheduler.reschedule(it) }
+                }
+            } finally {
+                result.finish()
+                executor.shutdown()
+            }
         }
     }
-    private companion object { val EXECUTOR = Executors.newSingleThreadExecutor() }
 }
 
 class FoodLogReminderDeliveryService : Service() {
@@ -85,9 +96,19 @@ class FoodLogReminderDeliveryService : Service() {
         notifications.createNotificationChannel(NotificationChannel(DELIVERY_CHANNEL, "Food Log reminder delivery", NotificationManager.IMPORTANCE_LOW).apply { setShowBadge(false) })
     }
     private fun finish(startId: Int) { if (stopSelfResult(startId)) stopForeground(STOP_FOREGROUND_REMOVE) }
-    private companion object {
-        const val REMINDER_CHANNEL = "food_log_reminders"; const val DELIVERY_CHANNEL = "food_log_reminder_delivery"; const val DELIVERY_ID = 0x464c; const val DELIVERY_LIFETIME_MS = 8_000L
-        fun start(context: Context, id: String, late: Boolean) = context.startForegroundService(Intent(context, FoodLogReminderDeliveryService::class.java).putExtra(FoodLogReminderContract.EXTRA_ID, id).putExtra(FoodLogReminderContract.EXTRA_LATE, late))
+    companion object {
+        private const val REMINDER_CHANNEL = "food_log_reminders"
+        private const val DELIVERY_CHANNEL = "food_log_reminder_delivery"
+        private const val DELIVERY_ID = 0x464c
+        private const val DELIVERY_LIFETIME_MS = 8_000L
+
+        internal fun start(context: Context, id: String, late: Boolean) {
+            context.startForegroundService(
+                Intent(context, FoodLogReminderDeliveryService::class.java)
+                    .putExtra(FoodLogReminderContract.EXTRA_ID, id)
+                    .putExtra(FoodLogReminderContract.EXTRA_LATE, late),
+            )
+        }
     }
 }
 

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderScheduling.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderScheduling.kt
@@ -18,16 +18,16 @@ internal object FoodLogReminderPlanner {
         else FoodLogAlarmPlan.Schedule(reminder.id, reminder.epochMillis)
 }
 
-internal interface FoodLogAlarmGateway { fun schedule(id: String, triggerAtMillis: Long, exact: Boolean): Boolean; fun cancel(id: String); fun deliverNow(id: String, late: Boolean) }
+internal interface FoodLogAlarmGateway { fun schedule(id: String, triggerAtMillis: Long, exact: Boolean, late: Boolean): Boolean; fun cancel(id: String); fun deliverNow(id: String, late: Boolean) }
 internal class FoodLogReminderScheduler(private val gateway: FoodLogAlarmGateway, private val exactAllowed: () -> Boolean, private val clock: () -> Long = System::currentTimeMillis) {
     fun schedule(reminder: FoodLogReminder, lateIfPassed: Boolean = false): Boolean = when (val plan = FoodLogReminderPlanner.plan(reminder, clock())) {
         is FoodLogAlarmPlan.DeliverImmediately -> { gateway.deliverNow(plan.id, lateIfPassed); true }
-        is FoodLogAlarmPlan.Schedule -> gateway.schedule(plan.id, plan.triggerAtMillis, exactAllowed())
+        is FoodLogAlarmPlan.Schedule -> gateway.schedule(plan.id, plan.triggerAtMillis, exactAllowed(), false)
     }
     /** Restart receivers only restore alarm state; they never begin a delivery themselves. */
     fun reschedule(reminder: FoodLogReminder): Boolean = when (val plan = FoodLogReminderPlanner.plan(reminder, clock())) {
-        is FoodLogAlarmPlan.DeliverImmediately -> gateway.schedule(plan.id, clock(), exactAllowed())
-        is FoodLogAlarmPlan.Schedule -> gateway.schedule(plan.id, plan.triggerAtMillis, exactAllowed())
+        is FoodLogAlarmPlan.DeliverImmediately -> gateway.schedule(plan.id, clock(), exactAllowed(), true)
+        is FoodLogAlarmPlan.Schedule -> gateway.schedule(plan.id, plan.triggerAtMillis, exactAllowed(), false)
     }
     fun cancel(id: String) = gateway.cancel(id)
 }
@@ -39,13 +39,15 @@ internal fun foodLogReminderScheduler(context: Context) = FoodLogReminderSchedul
 
 private class AndroidFoodLogAlarmGateway(private val context: Context) : FoodLogAlarmGateway {
     private val manager = context.getSystemService(AlarmManager::class.java)
-    override fun schedule(id: String, triggerAtMillis: Long, exact: Boolean): Boolean {
-        val operation = pendingIntent(id)
+    override fun schedule(id: String, triggerAtMillis: Long, exact: Boolean, late: Boolean): Boolean {
+        val operation = pendingIntent(id, late)
         if (exact) try { manager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, operation); return true } catch (_: SecurityException) { }
         manager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, operation); return false
     }
-    override fun cancel(id: String) = manager.cancel(pendingIntent(id))
-    override fun deliverNow(id: String, late: Boolean) = FoodLogReminderDeliveryService.start(context, id, late)
-    private fun pendingIntent(id: String): PendingIntent = PendingIntent.getBroadcast(context, id.hashCode(), Intent(context, FoodLogReminderReceiver::class.java).setAction(FoodLogReminderContract.ACTION_FIRE).setData(Uri.parse("nexus-foodlog://reminder/$id")).putExtra(FoodLogReminderContract.EXTRA_ID, id), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+    override fun cancel(id: String) = manager.cancel(pendingIntent(id, false))
+    override fun deliverNow(id: String, late: Boolean) {
+        FoodLogReminderDeliveryService.start(context, id, late)
+    }
+    private fun pendingIntent(id: String, late: Boolean): PendingIntent = PendingIntent.getBroadcast(context, id.hashCode(), Intent(context, FoodLogReminderReceiver::class.java).setAction(FoodLogReminderContract.ACTION_FIRE).setData(Uri.parse("nexus-foodlog://reminder/$id")).putExtra(FoodLogReminderContract.EXTRA_ID, id).putExtra(FoodLogReminderContract.EXTRA_LATE, late), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 }
 internal object FoodLogReminderContract { const val ACTION_FIRE = "com.anezium.rokidbus.plugin.foodlog.action.REMINDER_FIRE"; const val EXTRA_ID = "reminder_id"; const val EXTRA_LATE = "late" }

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderScheduling.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderScheduling.kt
@@ -1,0 +1,51 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+
+internal sealed interface FoodLogAlarmPlan {
+    data class Schedule(val id: String, val triggerAtMillis: Long) : FoodLogAlarmPlan
+    data class DeliverImmediately(val id: String) : FoodLogAlarmPlan
+}
+
+internal object FoodLogReminderPlanner {
+    fun plan(reminder: FoodLogReminder, nowMillis: Long): FoodLogAlarmPlan =
+        if (reminder.epochMillis <= nowMillis) FoodLogAlarmPlan.DeliverImmediately(reminder.id)
+        else FoodLogAlarmPlan.Schedule(reminder.id, reminder.epochMillis)
+}
+
+internal interface FoodLogAlarmGateway { fun schedule(id: String, triggerAtMillis: Long, exact: Boolean): Boolean; fun cancel(id: String); fun deliverNow(id: String, late: Boolean) }
+internal class FoodLogReminderScheduler(private val gateway: FoodLogAlarmGateway, private val exactAllowed: () -> Boolean, private val clock: () -> Long = System::currentTimeMillis) {
+    fun schedule(reminder: FoodLogReminder, lateIfPassed: Boolean = false): Boolean = when (val plan = FoodLogReminderPlanner.plan(reminder, clock())) {
+        is FoodLogAlarmPlan.DeliverImmediately -> { gateway.deliverNow(plan.id, lateIfPassed); true }
+        is FoodLogAlarmPlan.Schedule -> gateway.schedule(plan.id, plan.triggerAtMillis, exactAllowed())
+    }
+    /** Restart receivers only restore alarm state; they never begin a delivery themselves. */
+    fun reschedule(reminder: FoodLogReminder): Boolean = when (val plan = FoodLogReminderPlanner.plan(reminder, clock())) {
+        is FoodLogAlarmPlan.DeliverImmediately -> gateway.schedule(plan.id, clock(), exactAllowed())
+        is FoodLogAlarmPlan.Schedule -> gateway.schedule(plan.id, plan.triggerAtMillis, exactAllowed())
+    }
+    fun cancel(id: String) = gateway.cancel(id)
+}
+
+internal fun foodLogReminderScheduler(context: Context) = FoodLogReminderScheduler(
+    AndroidFoodLogAlarmGateway(context.applicationContext),
+    { Build.VERSION.SDK_INT < Build.VERSION_CODES.S || context.getSystemService(AlarmManager::class.java).canScheduleExactAlarms() },
+)
+
+private class AndroidFoodLogAlarmGateway(private val context: Context) : FoodLogAlarmGateway {
+    private val manager = context.getSystemService(AlarmManager::class.java)
+    override fun schedule(id: String, triggerAtMillis: Long, exact: Boolean): Boolean {
+        val operation = pendingIntent(id)
+        if (exact) try { manager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, operation); return true } catch (_: SecurityException) { }
+        manager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, operation); return false
+    }
+    override fun cancel(id: String) = manager.cancel(pendingIntent(id))
+    override fun deliverNow(id: String, late: Boolean) = FoodLogReminderDeliveryService.start(context, id, late)
+    private fun pendingIntent(id: String): PendingIntent = PendingIntent.getBroadcast(context, id.hashCode(), Intent(context, FoodLogReminderReceiver::class.java).setAction(FoodLogReminderContract.ACTION_FIRE).setData(Uri.parse("nexus-foodlog://reminder/$id")).putExtra(FoodLogReminderContract.EXTRA_ID, id), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+}
+internal object FoodLogReminderContract { const val ACTION_FIRE = "com.anezium.rokidbus.plugin.foodlog.action.REMINDER_FIRE"; const val EXTRA_ID = "reminder_id"; const val EXTRA_LATE = "late" }

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderStore.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderStore.kt
@@ -1,0 +1,135 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/** A reminder can only be created for an explicit meal or hydration prompt. */
+internal enum class FoodLogReminderKind { MEAL, HYDRATION }
+
+internal data class FoodLogReminder(
+    val id: String,
+    val kind: FoodLogReminderKind,
+    val label: String,
+    val epochMillis: Long,
+    val enabled: Boolean,
+)
+
+/** Thread-safe local persistence. Every mutation replaces the complete file atomically. */
+internal class FoodLogReminderStore internal constructor(
+    filesDir: File,
+    private val idGenerator: () -> String = { UUID.randomUUID().toString() },
+    private val fileOperations: FoodLogAtomicFileOperations = NioFoodLogAtomicFileOperations,
+) {
+    private val file = File(filesDir, FILE_NAME)
+
+    constructor(context: Context) : this(context.applicationContext.filesDir)
+
+    fun all(): List<FoodLogReminder> = synchronized(lock) { read().sortedBy(FoodLogReminder::epochMillis) }
+
+    fun get(id: String): FoodLogReminder? = synchronized(lock) { read().firstOrNull { it.id == id } }
+
+    fun create(kind: FoodLogReminderKind, label: String, epochMillis: Long, enabled: Boolean = true): FoodLogReminder = synchronized(lock) {
+        require(epochMillis > 0L)
+        val normalized = label.trim().take(MAX_LABEL_CHARS)
+        require(normalized.isNotEmpty())
+        val existing = read()
+        val reminder = FoodLogReminder(uniqueId(existing), kind, normalized, epochMillis, enabled)
+        persist(existing + reminder)
+        reminder
+    }
+
+    fun update(reminder: FoodLogReminder): Boolean = synchronized(lock) {
+        validate(reminder)
+        val existing = read()
+        if (existing.none { it.id == reminder.id }) return@synchronized false
+        persist(existing.map { if (it.id == reminder.id) reminder else it })
+        true
+    }
+
+    /** Removes exactly the supplied UUID after rereading the current persistent state. */
+    fun delete(id: String): FoodLogReminder? = synchronized(lock) {
+        val existing = read()
+        val exact = existing.firstOrNull { it.id == id } ?: return@synchronized null
+        persist(existing.filterNot { it.id == id })
+        exact
+    }
+
+    /** Cancellation is deliberately UUID-only; labels are never used as destructive identities. */
+    fun cancel(id: String): FoodLogReminder? = delete(id)
+
+    /** Atomically claims exactly one enabled item so an alarm cannot deliver twice. */
+    fun takeForDelivery(id: String): FoodLogReminder? = synchronized(lock) {
+        val existing = read()
+        val exact = existing.firstOrNull { it.id == id && it.enabled } ?: return@synchronized null
+        persist(existing.filterNot { it.id == id })
+        exact
+    }
+
+    private val lock: Any
+        get() = LOCKS.computeIfAbsent(file.absoluteFile.normalize().path) { Any() }
+
+    private fun uniqueId(existing: List<FoodLogReminder>): String {
+        repeat(100) {
+            val candidate = idGenerator()
+            if (UUID_PATTERN.matches(candidate) && existing.none { it.id == candidate }) return candidate
+        }
+        error("Unable to create a unique reminder UUID.")
+    }
+
+    private fun validate(value: FoodLogReminder) {
+        require(UUID_PATTERN.matches(value.id))
+        require(value.label.trim().isNotEmpty() && value.label.length <= MAX_LABEL_CHARS)
+        require(value.epochMillis > 0L)
+    }
+
+    private fun read(): List<FoodLogReminder> = runCatching {
+        if (!file.isFile) return emptyList()
+        val array = JSONObject(file.readText()).getJSONArray("reminders")
+        buildList {
+            for (index in 0 until array.length()) {
+                val item = array.getJSONObject(index)
+                val id = item.getString("id")
+                val kind = runCatching { FoodLogReminderKind.valueOf(item.getString("kind")) }.getOrNull()
+                val label = item.getString("label").trim().take(MAX_LABEL_CHARS)
+                if (kind != null && UUID_PATTERN.matches(id) && label.isNotEmpty()) {
+                    add(FoodLogReminder(id, kind, label, item.getLong("epochMillis"), item.getBoolean("enabled")))
+                }
+            }
+        }
+    }.getOrDefault(emptyList())
+
+    private fun persist(reminders: List<FoodLogReminder>) {
+        val json = JSONObject().put("version", 1).put("reminders", JSONArray().apply {
+            reminders.forEach { value -> put(JSONObject()
+                .put("id", value.id).put("kind", value.kind.name).put("label", value.label)
+                .put("epochMillis", value.epochMillis).put("enabled", value.enabled)) }
+        })
+        writeFoodLogJsonAtomically(file, json.toString(), fileOperations)
+    }
+
+    internal companion object {
+        const val MAX_LABEL_CHARS = 80
+        private const val FILE_NAME = "food_log_reminders_v1.json"
+        private val UUID_PATTERN = Regex("[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")
+        private val LOCKS = ConcurrentHashMap<String, Any>()
+    }
+}
+
+internal interface FoodLogAtomicFileOperations { fun atomicReplace(source: File, target: File); fun replace(source: File, target: File) }
+internal object NioFoodLogAtomicFileOperations : FoodLogAtomicFileOperations {
+    override fun atomicReplace(source: File, target: File) = Files.move(source.toPath(), target.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+    override fun replace(source: File, target: File) = Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+}
+internal fun writeFoodLogJsonAtomically(target: File, text: String, ops: FoodLogAtomicFileOperations = NioFoodLogAtomicFileOperations) {
+    val parent = checkNotNull(target.parentFile); if (!parent.isDirectory && !parent.mkdirs()) error("Reminder directory unavailable.")
+    val temporary = File(parent, ".${target.name}.tmp")
+    try { FileOutputStream(temporary).use { it.write(text.toByteArray()); it.flush(); it.fd.sync() }; try { ops.atomicReplace(temporary, target) } catch (_: AtomicMoveNotSupportedException) { ops.replace(temporary, target) } } finally { temporary.delete() }
+}

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderStore.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderStore.kt
@@ -54,6 +54,32 @@ internal class FoodLogReminderStore internal constructor(
         true
     }
 
+    /** Merges a fully validated backup by stable UUID and returns the imported values. */
+    fun merge(reminders: List<FoodLogReminder>): List<FoodLogReminder> = synchronized(lock) {
+        require(reminders.size <= MAX_REMINDERS)
+        reminders.forEach(::validate)
+        require(reminders.map(FoodLogReminder::id).toSet().size == reminders.size)
+        val existing = try {
+            read()
+        } catch (exception: Exception) {
+            quarantineCorruptFile()
+            emptyList()
+        }
+        val merged = existing.associateByTo(linkedMapOf(), FoodLogReminder::id)
+        reminders.forEach { merged[it.id] = it }
+        require(merged.size <= MAX_REMINDERS)
+        persist(merged.values.toList())
+        reminders
+    }
+
+    private fun quarantineCorruptFile() {
+        if (!file.isFile) return
+        val quarantine = generateSequence(0) { it + 1 }
+            .map { suffix -> File(file.parentFile, "${file.name}.corrupt-$suffix") }
+            .first { !it.exists() }
+        check(file.renameTo(quarantine)) { "Corrupt reminder data could not be preserved" }
+    }
+
     /** Removes exactly the supplied UUID after rereading the current persistent state. */
     fun delete(id: String): FoodLogReminder? = synchronized(lock) {
         val existing = read()
@@ -90,24 +116,27 @@ internal class FoodLogReminderStore internal constructor(
         require(value.epochMillis > 0L)
     }
 
-    private fun read(): List<FoodLogReminder> = runCatching {
+    private fun read(): List<FoodLogReminder> {
         if (!file.isFile) return emptyList()
-        val array = JSONObject(file.readText()).getJSONArray("reminders")
-        buildList {
+        val root = JSONObject(file.readText())
+        require(root.getInt("version") == FILE_VERSION) { "Unsupported reminder file" }
+        val array = root.getJSONArray("reminders")
+        require(array.length() <= MAX_REMINDERS) { "Too many reminders" }
+        val reminders = buildList {
             for (index in 0 until array.length()) {
                 val item = array.getJSONObject(index)
                 val id = item.getString("id")
-                val kind = runCatching { FoodLogReminderKind.valueOf(item.getString("kind")) }.getOrNull()
-                val label = item.getString("label").trim().take(MAX_LABEL_CHARS)
-                if (kind != null && UUID_PATTERN.matches(id) && label.isNotEmpty()) {
-                    add(FoodLogReminder(id, kind, label, item.getLong("epochMillis"), item.getBoolean("enabled")))
-                }
+                val kind = FoodLogReminderKind.valueOf(item.getString("kind"))
+                val label = item.getString("label")
+                add(FoodLogReminder(id, kind, label, item.getLong("epochMillis"), item.getBoolean("enabled")).also(::validate))
             }
         }
-    }.getOrDefault(emptyList())
+        require(reminders.map(FoodLogReminder::id).toSet().size == reminders.size) { "Duplicate reminder UUID" }
+        return reminders
+    }
 
     private fun persist(reminders: List<FoodLogReminder>) {
-        val json = JSONObject().put("version", 1).put("reminders", JSONArray().apply {
+        val json = JSONObject().put("version", FILE_VERSION).put("reminders", JSONArray().apply {
             reminders.forEach { value -> put(JSONObject()
                 .put("id", value.id).put("kind", value.kind.name).put("label", value.label)
                 .put("epochMillis", value.epochMillis).put("enabled", value.enabled)) }
@@ -117,6 +146,8 @@ internal class FoodLogReminderStore internal constructor(
 
     internal companion object {
         const val MAX_LABEL_CHARS = 80
+        const val MAX_REMINDERS = 5_000
+        private const val FILE_VERSION = 1
         private const val FILE_NAME = "food_log_reminders_v1.json"
         private val UUID_PATTERN = Regex("[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")
         private val LOCKS = ConcurrentHashMap<String, Any>()
@@ -125,8 +156,18 @@ internal class FoodLogReminderStore internal constructor(
 
 internal interface FoodLogAtomicFileOperations { fun atomicReplace(source: File, target: File); fun replace(source: File, target: File) }
 internal object NioFoodLogAtomicFileOperations : FoodLogAtomicFileOperations {
-    override fun atomicReplace(source: File, target: File) = Files.move(source.toPath(), target.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
-    override fun replace(source: File, target: File) = Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+    override fun atomicReplace(source: File, target: File) {
+        Files.move(
+            source.toPath(),
+            target.toPath(),
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING,
+        )
+    }
+
+    override fun replace(source: File, target: File) {
+        Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+    }
 }
 internal fun writeFoodLogJsonAtomically(target: File, text: String, ops: FoodLogAtomicFileOperations = NioFoodLogAtomicFileOperations) {
     val parent = checkNotNull(target.parentFile); if (!parent.isDirectory && !parent.mkdirs()) error("Reminder directory unavailable.")

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogStore.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogStore.kt
@@ -1,0 +1,295 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import java.time.ZoneId
+
+internal class FoodLogStore(context: Context) : AutoCloseable {
+    private val helper = FoodLogDatabase(context.applicationContext)
+
+    @Synchronized
+    fun product(barcode: String): FoodProduct? {
+        val normalized = normalizeBarcode(barcode) ?: return null
+        return helper.readableDatabase.query(
+            PRODUCTS,
+            PRODUCT_COLUMNS,
+            "$BARCODE = ?",
+            arrayOf(normalized),
+            null,
+            null,
+            null,
+            "1",
+        ).use { cursor -> if (cursor.moveToFirst()) cursor.toProduct() else null }
+    }
+
+    @Synchronized
+    fun upsertProduct(product: FoodProduct) {
+        helper.writableDatabase.insertWithOnConflict(
+            PRODUCTS,
+            null,
+            product.toValues(),
+            SQLiteDatabase.CONFLICT_REPLACE,
+        )
+    }
+
+    @Synchronized
+    fun addEntry(
+        product: FoodProduct,
+        quantityGrams: Double,
+        consumedAtMillis: Long = System.currentTimeMillis(),
+    ): Long {
+        require(quantityGrams in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS)
+        val db = helper.writableDatabase
+        db.beginTransaction()
+        return try {
+            db.insertWithOnConflict(
+                PRODUCTS,
+                null,
+                product.toValues(),
+                SQLiteDatabase.CONFLICT_REPLACE,
+            )
+            val values = product.toValues().apply {
+                remove(FETCHED_AT)
+                put(CONSUMED_AT, consumedAtMillis)
+                put(QUANTITY_GRAMS, quantityGrams)
+            }
+            val id = db.insertOrThrow(ENTRIES, null, values)
+            db.setTransactionSuccessful()
+            id
+        } finally {
+            db.endTransaction()
+        }
+    }
+
+    @Synchronized
+    fun entriesForDay(
+        atMillis: Long = System.currentTimeMillis(),
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): List<FoodEntry> {
+        val bounds = dayBounds(atMillis, zoneId)
+        return helper.readableDatabase.query(
+            ENTRIES,
+            ENTRY_COLUMNS,
+            "$CONSUMED_AT >= ? AND $CONSUMED_AT <= ?",
+            arrayOf(bounds.first.toString(), bounds.last.toString()),
+            null,
+            null,
+            "$CONSUMED_AT DESC, $ID DESC",
+        ).use { cursor -> cursor.mapRows(Cursor::toEntry) }
+    }
+
+    @Synchronized
+    fun recentProducts(limit: Int = 8): List<FoodProduct> =
+        helper.readableDatabase.rawQuery(
+            """
+            SELECT ${PRODUCT_COLUMNS.joinToString(", ") { "p.$it" }}
+            FROM $PRODUCTS p
+            INNER JOIN $ENTRIES e ON e.$BARCODE = p.$BARCODE
+            GROUP BY p.$BARCODE
+            ORDER BY MAX(e.$CONSUMED_AT) DESC
+            LIMIT ?
+            """.trimIndent(),
+            arrayOf(limit.coerceIn(1, 32).toString()),
+        ).use { cursor -> cursor.mapRows(Cursor::toProduct) }
+
+    @Synchronized
+    fun latestEntryForDay(atMillis: Long = System.currentTimeMillis()): FoodEntry? =
+        entriesForDay(atMillis).firstOrNull()
+
+    @Synchronized
+    fun deleteEntry(id: Long): Boolean =
+        helper.writableDatabase.delete(ENTRIES, "$ID = ?", arrayOf(id.toString())) == 1
+
+    override fun close() {
+        helper.close()
+    }
+
+    private class FoodLogDatabase(context: Context) :
+        SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+        override fun onCreate(db: SQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE $PRODUCTS (
+                    $BARCODE TEXT PRIMARY KEY NOT NULL,
+                    $PRODUCT_NAME TEXT NOT NULL,
+                    $BRAND TEXT NOT NULL,
+                    $SERVING_LABEL TEXT,
+                    $SERVING_GRAMS REAL,
+                    $NUTRITION_GRADE TEXT,
+                    $NOVA_GROUP INTEGER,
+                    $CALORIES_100G REAL,
+                    $PROTEIN_100G REAL,
+                    $CARBOHYDRATE_100G REAL,
+                    $FAT_100G REAL,
+                    $SUGARS_100G REAL,
+                    $FIBER_100G REAL,
+                    $SALT_100G REAL,
+                    $FETCHED_AT INTEGER NOT NULL
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                CREATE TABLE $ENTRIES (
+                    $ID INTEGER PRIMARY KEY AUTOINCREMENT,
+                    $CONSUMED_AT INTEGER NOT NULL,
+                    $QUANTITY_GRAMS REAL NOT NULL,
+                    $BARCODE TEXT NOT NULL,
+                    $PRODUCT_NAME TEXT NOT NULL,
+                    $BRAND TEXT NOT NULL,
+                    $SERVING_LABEL TEXT,
+                    $SERVING_GRAMS REAL,
+                    $NUTRITION_GRADE TEXT,
+                    $NOVA_GROUP INTEGER,
+                    $CALORIES_100G REAL,
+                    $PROTEIN_100G REAL,
+                    $CARBOHYDRATE_100G REAL,
+                    $FAT_100G REAL,
+                    $SUGARS_100G REAL,
+                    $FIBER_100G REAL,
+                    $SALT_100G REAL
+                )
+                """.trimIndent(),
+            )
+            db.execSQL("CREATE INDEX entries_consumed_at ON $ENTRIES ($CONSUMED_AT DESC)")
+            db.execSQL("CREATE INDEX entries_barcode ON $ENTRIES ($BARCODE)")
+        }
+
+        override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+    }
+
+    private companion object {
+        const val DATABASE_NAME = "food-log.db"
+        const val DATABASE_VERSION = 1
+        const val PRODUCTS = "products"
+        const val ENTRIES = "entries"
+        const val ID = "id"
+        const val CONSUMED_AT = "consumed_at"
+        const val QUANTITY_GRAMS = "quantity_grams"
+        const val BARCODE = "barcode"
+        const val PRODUCT_NAME = "product_name"
+        const val BRAND = "brand"
+        const val SERVING_LABEL = "serving_label"
+        const val SERVING_GRAMS = "serving_grams"
+        const val NUTRITION_GRADE = "nutrition_grade"
+        const val NOVA_GROUP = "nova_group"
+        const val CALORIES_100G = "calories_100g"
+        const val PROTEIN_100G = "protein_100g"
+        const val CARBOHYDRATE_100G = "carbohydrate_100g"
+        const val FAT_100G = "fat_100g"
+        const val SUGARS_100G = "sugars_100g"
+        const val FIBER_100G = "fiber_100g"
+        const val SALT_100G = "salt_100g"
+        const val FETCHED_AT = "fetched_at"
+
+        val PRODUCT_COLUMNS = arrayOf(
+            BARCODE,
+            PRODUCT_NAME,
+            BRAND,
+            SERVING_LABEL,
+            SERVING_GRAMS,
+            NUTRITION_GRADE,
+            NOVA_GROUP,
+            CALORIES_100G,
+            PROTEIN_100G,
+            CARBOHYDRATE_100G,
+            FAT_100G,
+            SUGARS_100G,
+            FIBER_100G,
+            SALT_100G,
+            FETCHED_AT,
+        )
+        val ENTRY_COLUMNS = arrayOf(
+            ID,
+            CONSUMED_AT,
+            QUANTITY_GRAMS,
+            *PRODUCT_COLUMNS.filterNot { it == FETCHED_AT }.toTypedArray(),
+        )
+    }
+}
+
+internal const val MIN_QUANTITY_GRAMS = 1.0
+internal const val MAX_QUANTITY_GRAMS = 5_000.0
+
+private fun FoodProduct.toValues(): ContentValues = ContentValues().apply {
+    put("barcode", barcode)
+    put("product_name", name)
+    put("brand", brand)
+    putNullable("serving_label", servingLabel)
+    putNullable("serving_grams", servingGrams)
+    putNullable("nutrition_grade", nutritionGrade)
+    putNullable("nova_group", novaGroup)
+    putNullable("calories_100g", nutrients.caloriesKcal)
+    putNullable("protein_100g", nutrients.proteinGrams)
+    putNullable("carbohydrate_100g", nutrients.carbohydrateGrams)
+    putNullable("fat_100g", nutrients.fatGrams)
+    putNullable("sugars_100g", nutrients.sugarsGrams)
+    putNullable("fiber_100g", nutrients.fiberGrams)
+    putNullable("salt_100g", nutrients.saltGrams)
+    put("fetched_at", fetchedAtMillis)
+}
+
+private fun ContentValues.putNullable(key: String, value: String?) {
+    if (value == null) putNull(key) else put(key, value)
+}
+
+private fun ContentValues.putNullable(key: String, value: Double?) {
+    if (value == null) putNull(key) else put(key, value)
+}
+
+private fun ContentValues.putNullable(key: String, value: Int?) {
+    if (value == null) putNull(key) else put(key, value)
+}
+
+private fun Cursor.toProduct(): FoodProduct = FoodProduct(
+    barcode = string("barcode"),
+    name = string("product_name"),
+    brand = string("brand"),
+    servingLabel = nullableString("serving_label"),
+    servingGrams = nullableDouble("serving_grams"),
+    nutritionGrade = nullableString("nutrition_grade"),
+    novaGroup = nullableInt("nova_group"),
+    nutrients = NutrientsPer100g(
+        caloriesKcal = nullableDouble("calories_100g"),
+        proteinGrams = nullableDouble("protein_100g"),
+        carbohydrateGrams = nullableDouble("carbohydrate_100g"),
+        fatGrams = nullableDouble("fat_100g"),
+        sugarsGrams = nullableDouble("sugars_100g"),
+        fiberGrams = nullableDouble("fiber_100g"),
+        saltGrams = nullableDouble("salt_100g"),
+    ),
+    fetchedAtMillis = columnIndexOrNull("fetched_at")?.let(::getLong) ?: 0L,
+)
+
+private fun Cursor.toEntry(): FoodEntry = FoodEntry(
+    id = getLong(getColumnIndexOrThrow("id")),
+    consumedAtMillis = getLong(getColumnIndexOrThrow("consumed_at")),
+    quantityGrams = getDouble(getColumnIndexOrThrow("quantity_grams")),
+    product = toProduct(),
+)
+
+private fun Cursor.string(name: String): String = getString(getColumnIndexOrThrow(name))
+
+private fun Cursor.nullableString(name: String): String? {
+    val index = getColumnIndexOrThrow(name)
+    return if (isNull(index)) null else getString(index)
+}
+
+private fun Cursor.nullableDouble(name: String): Double? {
+    val index = getColumnIndexOrThrow(name)
+    return if (isNull(index)) null else getDouble(index)
+}
+
+private fun Cursor.nullableInt(name: String): Int? {
+    val index = getColumnIndexOrThrow(name)
+    return if (isNull(index)) null else getInt(index)
+}
+
+private fun Cursor.columnIndexOrNull(name: String): Int? = getColumnIndex(name).takeIf { it >= 0 }
+
+private inline fun <T> Cursor.mapRows(transform: (Cursor) -> T): List<T> = buildList {
+    while (moveToNext()) add(transform(this@mapRows))
+}

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogStore.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogStore.kt
@@ -6,290 +6,74 @@ import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import java.time.ZoneId
-
-internal class FoodLogStore(context: Context) : AutoCloseable {
-    private val helper = FoodLogDatabase(context.applicationContext)
-
-    @Synchronized
-    fun product(barcode: String): FoodProduct? {
-        val normalized = normalizeBarcode(barcode) ?: return null
-        return helper.readableDatabase.query(
-            PRODUCTS,
-            PRODUCT_COLUMNS,
-            "$BARCODE = ?",
-            arrayOf(normalized),
-            null,
-            null,
-            null,
-            "1",
-        ).use { cursor -> if (cursor.moveToFirst()) cursor.toProduct() else null }
-    }
-
-    @Synchronized
-    fun upsertProduct(product: FoodProduct) {
-        helper.writableDatabase.insertWithOnConflict(
-            PRODUCTS,
-            null,
-            product.toValues(),
-            SQLiteDatabase.CONFLICT_REPLACE,
-        )
-    }
-
-    @Synchronized
-    fun addEntry(
-        product: FoodProduct,
-        quantityGrams: Double,
-        consumedAtMillis: Long = System.currentTimeMillis(),
-    ): Long {
-        require(quantityGrams in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS)
-        val db = helper.writableDatabase
-        db.beginTransaction()
-        return try {
-            db.insertWithOnConflict(
-                PRODUCTS,
-                null,
-                product.toValues(),
-                SQLiteDatabase.CONFLICT_REPLACE,
-            )
-            val values = product.toValues().apply {
-                remove(FETCHED_AT)
-                put(CONSUMED_AT, consumedAtMillis)
-                put(QUANTITY_GRAMS, quantityGrams)
-            }
-            val id = db.insertOrThrow(ENTRIES, null, values)
-            db.setTransactionSuccessful()
-            id
-        } finally {
-            db.endTransaction()
-        }
-    }
-
-    @Synchronized
-    fun entriesForDay(
-        atMillis: Long = System.currentTimeMillis(),
-        zoneId: ZoneId = ZoneId.systemDefault(),
-    ): List<FoodEntry> {
-        val bounds = dayBounds(atMillis, zoneId)
-        return helper.readableDatabase.query(
-            ENTRIES,
-            ENTRY_COLUMNS,
-            "$CONSUMED_AT >= ? AND $CONSUMED_AT <= ?",
-            arrayOf(bounds.first.toString(), bounds.last.toString()),
-            null,
-            null,
-            "$CONSUMED_AT DESC, $ID DESC",
-        ).use { cursor -> cursor.mapRows(Cursor::toEntry) }
-    }
-
-    @Synchronized
-    fun recentProducts(limit: Int = 8): List<FoodProduct> =
-        helper.readableDatabase.rawQuery(
-            """
-            SELECT ${PRODUCT_COLUMNS.joinToString(", ") { "p.$it" }}
-            FROM $PRODUCTS p
-            INNER JOIN $ENTRIES e ON e.$BARCODE = p.$BARCODE
-            GROUP BY p.$BARCODE
-            ORDER BY MAX(e.$CONSUMED_AT) DESC
-            LIMIT ?
-            """.trimIndent(),
-            arrayOf(limit.coerceIn(1, 32).toString()),
-        ).use { cursor -> cursor.mapRows(Cursor::toProduct) }
-
-    @Synchronized
-    fun latestEntryForDay(atMillis: Long = System.currentTimeMillis()): FoodEntry? =
-        entriesForDay(atMillis).firstOrNull()
-
-    @Synchronized
-    fun deleteEntry(id: Long): Boolean =
-        helper.writableDatabase.delete(ENTRIES, "$ID = ?", arrayOf(id.toString())) == 1
-
-    override fun close() {
-        helper.close()
-    }
-
-    private class FoodLogDatabase(context: Context) :
-        SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
-        override fun onCreate(db: SQLiteDatabase) {
-            db.execSQL(
-                """
-                CREATE TABLE $PRODUCTS (
-                    $BARCODE TEXT PRIMARY KEY NOT NULL,
-                    $PRODUCT_NAME TEXT NOT NULL,
-                    $BRAND TEXT NOT NULL,
-                    $SERVING_LABEL TEXT,
-                    $SERVING_GRAMS REAL,
-                    $NUTRITION_GRADE TEXT,
-                    $NOVA_GROUP INTEGER,
-                    $CALORIES_100G REAL,
-                    $PROTEIN_100G REAL,
-                    $CARBOHYDRATE_100G REAL,
-                    $FAT_100G REAL,
-                    $SUGARS_100G REAL,
-                    $FIBER_100G REAL,
-                    $SALT_100G REAL,
-                    $FETCHED_AT INTEGER NOT NULL
-                )
-                """.trimIndent(),
-            )
-            db.execSQL(
-                """
-                CREATE TABLE $ENTRIES (
-                    $ID INTEGER PRIMARY KEY AUTOINCREMENT,
-                    $CONSUMED_AT INTEGER NOT NULL,
-                    $QUANTITY_GRAMS REAL NOT NULL,
-                    $BARCODE TEXT NOT NULL,
-                    $PRODUCT_NAME TEXT NOT NULL,
-                    $BRAND TEXT NOT NULL,
-                    $SERVING_LABEL TEXT,
-                    $SERVING_GRAMS REAL,
-                    $NUTRITION_GRADE TEXT,
-                    $NOVA_GROUP INTEGER,
-                    $CALORIES_100G REAL,
-                    $PROTEIN_100G REAL,
-                    $CARBOHYDRATE_100G REAL,
-                    $FAT_100G REAL,
-                    $SUGARS_100G REAL,
-                    $FIBER_100G REAL,
-                    $SALT_100G REAL
-                )
-                """.trimIndent(),
-            )
-            db.execSQL("CREATE INDEX entries_consumed_at ON $ENTRIES ($CONSUMED_AT DESC)")
-            db.execSQL("CREATE INDEX entries_barcode ON $ENTRIES ($BARCODE)")
-        }
-
-        override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
-    }
-
-    private companion object {
-        const val DATABASE_NAME = "food-log.db"
-        const val DATABASE_VERSION = 1
-        const val PRODUCTS = "products"
-        const val ENTRIES = "entries"
-        const val ID = "id"
-        const val CONSUMED_AT = "consumed_at"
-        const val QUANTITY_GRAMS = "quantity_grams"
-        const val BARCODE = "barcode"
-        const val PRODUCT_NAME = "product_name"
-        const val BRAND = "brand"
-        const val SERVING_LABEL = "serving_label"
-        const val SERVING_GRAMS = "serving_grams"
-        const val NUTRITION_GRADE = "nutrition_grade"
-        const val NOVA_GROUP = "nova_group"
-        const val CALORIES_100G = "calories_100g"
-        const val PROTEIN_100G = "protein_100g"
-        const val CARBOHYDRATE_100G = "carbohydrate_100g"
-        const val FAT_100G = "fat_100g"
-        const val SUGARS_100G = "sugars_100g"
-        const val FIBER_100G = "fiber_100g"
-        const val SALT_100G = "salt_100g"
-        const val FETCHED_AT = "fetched_at"
-
-        val PRODUCT_COLUMNS = arrayOf(
-            BARCODE,
-            PRODUCT_NAME,
-            BRAND,
-            SERVING_LABEL,
-            SERVING_GRAMS,
-            NUTRITION_GRADE,
-            NOVA_GROUP,
-            CALORIES_100G,
-            PROTEIN_100G,
-            CARBOHYDRATE_100G,
-            FAT_100G,
-            SUGARS_100G,
-            FIBER_100G,
-            SALT_100G,
-            FETCHED_AT,
-        )
-        val ENTRY_COLUMNS = arrayOf(
-            ID,
-            CONSUMED_AT,
-            QUANTITY_GRAMS,
-            *PRODUCT_COLUMNS.filterNot { it == FETCHED_AT }.toTypedArray(),
-        )
-    }
-}
+import java.util.UUID
 
 internal const val MIN_QUANTITY_GRAMS = 1.0
 internal const val MAX_QUANTITY_GRAMS = 5_000.0
 
-private fun FoodProduct.toValues(): ContentValues = ContentValues().apply {
-    put("barcode", barcode)
-    put("product_name", name)
-    put("brand", brand)
-    putNullable("serving_label", servingLabel)
-    putNullable("serving_grams", servingGrams)
-    putNullable("nutrition_grade", nutritionGrade)
-    putNullable("nova_group", novaGroup)
-    putNullable("calories_100g", nutrients.caloriesKcal)
-    putNullable("protein_100g", nutrients.proteinGrams)
-    putNullable("carbohydrate_100g", nutrients.carbohydrateGrams)
-    putNullable("fat_100g", nutrients.fatGrams)
-    putNullable("sugars_100g", nutrients.sugarsGrams)
-    putNullable("fiber_100g", nutrients.fiberGrams)
-    putNullable("salt_100g", nutrients.saltGrams)
-    put("fetched_at", fetchedAtMillis)
+/** The entry table deliberately contains a full nutrition snapshot. Product edits never rewrite history. */
+internal class FoodLogStore(context: Context) : AutoCloseable {
+    private val helper = FoodLogDatabase(context.applicationContext)
+
+    @Synchronized fun product(barcode: String): FoodProduct? {
+        val normalized = productId(barcode) ?: return null
+        return helper.readableDatabase.query("products", PRODUCT_COLUMNS, "barcode=?", arrayOf(normalized), null, null, null).use { if (it.moveToFirst()) it.toProduct() else null }
+    }
+    @Synchronized fun upsertProduct(product: FoodProduct) { helper.writableDatabase.insertWithOnConflict("products", null, product.values(), SQLiteDatabase.CONFLICT_REPLACE) }
+    @Synchronized fun createCustomFood(name: String, nutrients: NutrientsPer100g, brand: String = ""): FoodProduct {
+        require(name.isNotBlank() && name.length <= 300)
+        return FoodProduct("custom-" + UUID.randomUUID(), name.trim(), brand.trim(), null, null, null, null, nutrients, System.currentTimeMillis()).also(::upsertProduct)
+    }
+    @Synchronized fun addEntry(product: FoodProduct, quantityGrams: Double, consumedAtMillis: Long = System.currentTimeMillis()): Long =
+        addEntry(product, quantityGrams, consumedAtMillis, MealType.UNKNOWN, FoodEntrySource.UNKNOWN)
+    @Synchronized fun addEntry(product: FoodProduct, quantityGrams: Double, consumedAtMillis: Long, mealType: MealType, source: FoodEntrySource, recipeId: String? = null, uuid: String = UUID.randomUUID().toString()): Long {
+        require(quantityGrams in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS); require(uuid.length in 1..64)
+        val db = helper.writableDatabase; db.beginTransaction()
+        return try { db.insertWithOnConflict("products", null, product.values(), SQLiteDatabase.CONFLICT_REPLACE)
+            db.insertOrThrow("entries", null, product.values().apply { remove("fetched_at"); put("consumed_at", consumedAtMillis); put("quantity_grams", quantityGrams); put("entry_uuid", uuid); put("meal_type", mealType.name); put("source", source.name); putNullable("recipe_id", recipeId) }).also { db.setTransactionSuccessful() }
+        } finally { db.endTransaction() }
+    }
+    @Synchronized fun entriesForDay(atMillis: Long = System.currentTimeMillis(), zoneId: ZoneId = ZoneId.systemDefault()): List<FoodEntry> { val b=dayBounds(atMillis,zoneId); return entriesBetween(b.first,b.last) }
+    @Synchronized fun entriesBetween(startMillis: Long, endMillisInclusive: Long): List<FoodEntry> {
+        require(startMillis <= endMillisInclusive)
+        return helper.readableDatabase.query("entries", ENTRY_COLUMNS, "consumed_at>=? AND consumed_at<=?", arrayOf(startMillis.toString(),endMillisInclusive.toString()),null,null,"consumed_at DESC,id DESC").use { it.rows(Cursor::toEntry) }
+    }
+    @Synchronized fun dailySummary(atMillis: Long = System.currentTimeMillis(), zoneId: ZoneId = ZoneId.systemDefault()) = aggregateNutrition(entriesForDay(atMillis, zoneId))
+    @Synchronized fun weeklySummary(atMillis: Long = System.currentTimeMillis(), zoneId: ZoneId = ZoneId.systemDefault()): DailyNutritionTotals { val b=dayBounds(atMillis,zoneId); return aggregateNutrition(entriesBetween(b.first - 6L*24*60*60*1000, b.last)) }
+    @Synchronized fun recentProducts(limit: Int = 8): List<FoodProduct> = helper.readableDatabase.rawQuery("SELECT ${PRODUCT_COLUMNS.joinToString { "p.$it" }} FROM products p INNER JOIN entries e ON e.barcode=p.barcode GROUP BY p.barcode ORDER BY MAX(e.consumed_at) DESC LIMIT ?", arrayOf(limit.coerceIn(1,32).toString())).use { it.rows(Cursor::toProduct) }
+    @Synchronized fun latestEntryForDay(atMillis: Long = System.currentTimeMillis()): FoodEntry? = entriesForDay(atMillis).firstOrNull()
+    @Synchronized fun deleteEntry(id: Long): Boolean = helper.writableDatabase.delete("entries", "id=?", arrayOf(id.toString())) == 1
+    @Synchronized fun setFavorite(barcode: String, favorite: Boolean) { val code=productId(barcode)?:return; if(favorite) helper.writableDatabase.insertWithOnConflict("favorites",null,ContentValues().apply{put("barcode",code)},SQLiteDatabase.CONFLICT_IGNORE) else helper.writableDatabase.delete("favorites","barcode=?",arrayOf(code)) }
+    @Synchronized fun favoriteProducts(): List<FoodProduct> = helper.readableDatabase.rawQuery("SELECT ${PRODUCT_COLUMNS.joinToString()} FROM products WHERE barcode IN (SELECT barcode FROM favorites) ORDER BY product_name",null).use { it.rows(Cursor::toProduct) }
+    @Synchronized fun saveGoals(goals: NutritionGoals) { helper.writableDatabase.insertWithOnConflict("goals",null,ContentValues().apply { put("singleton",1); putNullable("calories",goals.caloriesKcal);putNullable("protein",goals.proteinGrams);putNullable("carbohydrate",goals.carbohydrateGrams);putNullable("fat",goals.fatGrams) },SQLiteDatabase.CONFLICT_REPLACE) }
+    @Synchronized fun goals(): NutritionGoals? = helper.readableDatabase.query("goals",arrayOf("calories","protein","carbohydrate","fat"),"singleton=1",null,null,null,null).use { if(it.moveToFirst()) NutritionGoals(it.d("calories"),it.d("protein"),it.d("carbohydrate"),it.d("fat")) else null }
+    @Synchronized fun saveRecipe(recipe: FoodRecipe) { val db=helper.writableDatabase; db.beginTransaction(); try { db.insertWithOnConflict("recipes",null,ContentValues().apply{put("recipe_uuid",recipe.uuid);put("name",recipe.name);put("servings",recipe.servings);put("created_at",recipe.createdAtMillis)},SQLiteDatabase.CONFLICT_REPLACE); db.delete("recipe_ingredients","recipe_uuid=?",arrayOf(recipe.uuid)); recipe.ingredients.forEach { i -> db.insertOrThrow("recipe_ingredients",null,ContentValues().apply { put("recipe_uuid",recipe.uuid);put("barcode",i.product.barcode);put("grams",i.grams) }) }; db.setTransactionSuccessful() } finally { db.endTransaction() } }
+    @Synchronized fun exportJson(): String = FoodLogBackup.encode(entriesBetween(0, Long.MAX_VALUE))
+    /** Validates the complete payload before opening the write transaction; UUIDs make merging idempotent. */
+    @Synchronized fun importJson(json: String): Int {
+        val entries = FoodLogBackup.decode(json)
+        val db = helper.writableDatabase; var inserted = 0; db.beginTransaction()
+        try { entries.forEach { entry ->
+            val exists = db.query("entries", arrayOf("id"), "entry_uuid=?", arrayOf(entry.uuid), null, null, null).use { it.moveToFirst() }
+            if (!exists) { db.insertWithOnConflict("products", null, entry.product.values(), SQLiteDatabase.CONFLICT_REPLACE)
+                db.insertOrThrow("entries", null, entry.product.values().apply { remove("fetched_at"); put("consumed_at",entry.consumedAtMillis);put("quantity_grams",entry.quantityGrams);put("entry_uuid",entry.uuid);put("meal_type",entry.mealType.name);put("source",entry.source.name);putNullable("recipe_id",entry.recipeId) }); inserted++ }
+        }; db.setTransactionSuccessful(); return inserted } finally { db.endTransaction() }
+    }
+    override fun close() = helper.close()
+    private class FoodLogDatabase(context: Context): SQLiteOpenHelper(context,"food-log.db",null,2) {
+        override fun onCreate(db: SQLiteDatabase) { createV1(db); upgradeTo2(db) }
+        override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) { if(oldVersion < 2) upgradeTo2(db) }
+        private fun createV1(db: SQLiteDatabase) { db.execSQL("CREATE TABLE products (barcode TEXT PRIMARY KEY NOT NULL, product_name TEXT NOT NULL, brand TEXT NOT NULL, serving_label TEXT, serving_grams REAL, nutrition_grade TEXT, nova_group INTEGER, calories_100g REAL, protein_100g REAL, carbohydrate_100g REAL, fat_100g REAL, sugars_100g REAL, fiber_100g REAL, salt_100g REAL, fetched_at INTEGER NOT NULL)"); db.execSQL("CREATE TABLE entries (id INTEGER PRIMARY KEY AUTOINCREMENT, consumed_at INTEGER NOT NULL, quantity_grams REAL NOT NULL, barcode TEXT NOT NULL, product_name TEXT NOT NULL, brand TEXT NOT NULL, serving_label TEXT, serving_grams REAL, nutrition_grade TEXT, nova_group INTEGER, calories_100g REAL, protein_100g REAL, carbohydrate_100g REAL, fat_100g REAL, sugars_100g REAL, fiber_100g REAL, salt_100g REAL)"); db.execSQL("CREATE INDEX entries_consumed_at ON entries (consumed_at DESC)") }
+        private fun upgradeTo2(db: SQLiteDatabase) { listOf("saturated_fat_100g REAL","sodium_100g REAL","cholesterol_100g REAL","potassium_100g REAL","calcium_100g REAL","iron_100g REAL","caffeine_100g REAL").forEach { c -> db.execSQL("ALTER TABLE products ADD COLUMN $c"); db.execSQL("ALTER TABLE entries ADD COLUMN $c") }; db.execSQL("ALTER TABLE entries ADD COLUMN entry_uuid TEXT"); db.execSQL("ALTER TABLE entries ADD COLUMN meal_type TEXT NOT NULL DEFAULT 'UNKNOWN'"); db.execSQL("ALTER TABLE entries ADD COLUMN source TEXT NOT NULL DEFAULT 'UNKNOWN'"); db.execSQL("ALTER TABLE entries ADD COLUMN recipe_id TEXT"); db.execSQL("UPDATE entries SET entry_uuid = lower(hex(randomblob(16))) WHERE entry_uuid IS NULL"); db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS entries_uuid ON entries(entry_uuid)"); db.execSQL("CREATE TABLE IF NOT EXISTS favorites (barcode TEXT PRIMARY KEY NOT NULL)"); db.execSQL("CREATE TABLE IF NOT EXISTS goals (singleton INTEGER PRIMARY KEY CHECK(singleton=1), calories REAL, protein REAL, carbohydrate REAL, fat REAL)"); db.execSQL("CREATE TABLE IF NOT EXISTS recipes (recipe_uuid TEXT PRIMARY KEY NOT NULL, name TEXT NOT NULL, servings REAL NOT NULL, created_at INTEGER NOT NULL)"); db.execSQL("CREATE TABLE IF NOT EXISTS recipe_ingredients (recipe_uuid TEXT NOT NULL, barcode TEXT NOT NULL, grams REAL NOT NULL, PRIMARY KEY(recipe_uuid, barcode))") }
+    }
+    private companion object { val PRODUCT_COLUMNS=arrayOf("barcode","product_name","brand","serving_label","serving_grams","nutrition_grade","nova_group","calories_100g","protein_100g","carbohydrate_100g","fat_100g","sugars_100g","fiber_100g","salt_100g","saturated_fat_100g","sodium_100g","cholesterol_100g","potassium_100g","calcium_100g","iron_100g","caffeine_100g","fetched_at"); val ENTRY_COLUMNS=arrayOf("id","consumed_at","quantity_grams","entry_uuid","meal_type","source","recipe_id",*PRODUCT_COLUMNS.filterNot { it=="fetched_at" }.toTypedArray()) }
 }
-
-private fun ContentValues.putNullable(key: String, value: String?) {
-    if (value == null) putNull(key) else put(key, value)
-}
-
-private fun ContentValues.putNullable(key: String, value: Double?) {
-    if (value == null) putNull(key) else put(key, value)
-}
-
-private fun ContentValues.putNullable(key: String, value: Int?) {
-    if (value == null) putNull(key) else put(key, value)
-}
-
-private fun Cursor.toProduct(): FoodProduct = FoodProduct(
-    barcode = string("barcode"),
-    name = string("product_name"),
-    brand = string("brand"),
-    servingLabel = nullableString("serving_label"),
-    servingGrams = nullableDouble("serving_grams"),
-    nutritionGrade = nullableString("nutrition_grade"),
-    novaGroup = nullableInt("nova_group"),
-    nutrients = NutrientsPer100g(
-        caloriesKcal = nullableDouble("calories_100g"),
-        proteinGrams = nullableDouble("protein_100g"),
-        carbohydrateGrams = nullableDouble("carbohydrate_100g"),
-        fatGrams = nullableDouble("fat_100g"),
-        sugarsGrams = nullableDouble("sugars_100g"),
-        fiberGrams = nullableDouble("fiber_100g"),
-        saltGrams = nullableDouble("salt_100g"),
-    ),
-    fetchedAtMillis = columnIndexOrNull("fetched_at")?.let(::getLong) ?: 0L,
-)
-
-private fun Cursor.toEntry(): FoodEntry = FoodEntry(
-    id = getLong(getColumnIndexOrThrow("id")),
-    consumedAtMillis = getLong(getColumnIndexOrThrow("consumed_at")),
-    quantityGrams = getDouble(getColumnIndexOrThrow("quantity_grams")),
-    product = toProduct(),
-)
-
-private fun Cursor.string(name: String): String = getString(getColumnIndexOrThrow(name))
-
-private fun Cursor.nullableString(name: String): String? {
-    val index = getColumnIndexOrThrow(name)
-    return if (isNull(index)) null else getString(index)
-}
-
-private fun Cursor.nullableDouble(name: String): Double? {
-    val index = getColumnIndexOrThrow(name)
-    return if (isNull(index)) null else getDouble(index)
-}
-
-private fun Cursor.nullableInt(name: String): Int? {
-    val index = getColumnIndexOrThrow(name)
-    return if (isNull(index)) null else getInt(index)
-}
-
-private fun Cursor.columnIndexOrNull(name: String): Int? = getColumnIndex(name).takeIf { it >= 0 }
-
-private inline fun <T> Cursor.mapRows(transform: (Cursor) -> T): List<T> = buildList {
-    while (moveToNext()) add(transform(this@mapRows))
-}
+private fun FoodProduct.values()=ContentValues().apply { put("barcode",barcode);put("product_name",name);put("brand",brand);putNullable("serving_label",servingLabel);putNullable("serving_grams",servingGrams);putNullable("nutrition_grade",nutritionGrade);putNullable("nova_group",novaGroup); listOf("calories_100g" to nutrients.caloriesKcal,"protein_100g" to nutrients.proteinGrams,"carbohydrate_100g" to nutrients.carbohydrateGrams,"fat_100g" to nutrients.fatGrams,"sugars_100g" to nutrients.sugarsGrams,"fiber_100g" to nutrients.fiberGrams,"salt_100g" to nutrients.saltGrams,"saturated_fat_100g" to nutrients.saturatedFatGrams,"sodium_100g" to nutrients.sodiumMilligrams,"cholesterol_100g" to nutrients.cholesterolMilligrams,"potassium_100g" to nutrients.potassiumMilligrams,"calcium_100g" to nutrients.calciumMilligrams,"iron_100g" to nutrients.ironMilligrams,"caffeine_100g" to nutrients.caffeineMilligrams).forEach{putNullable(it.first,it.second)};put("fetched_at",fetchedAtMillis) }
+internal fun productId(value: String): String? = normalizeBarcode(value) ?: value.takeIf { it.matches(Regex("custom-[A-Za-z0-9-]{1,64}")) }
+private fun ContentValues.putNullable(k:String,v:String?){if(v==null)putNull(k)else put(k,v)}
+private fun ContentValues.putNullable(k:String,v:Double?){if(v==null)putNull(k)else put(k,v)}
+private fun ContentValues.putNullable(k:String,v:Int?){if(v==null)putNull(k)else put(k,v)}
+private fun Cursor.toProduct()=FoodProduct(s("barcode"),s("product_name"),s("brand"),ns("serving_label"),d("serving_grams"),ns("nutrition_grade"),i("nova_group"),NutrientsPer100g(d("calories_100g"),d("protein_100g"),d("carbohydrate_100g"),d("fat_100g"),d("sugars_100g"),d("fiber_100g"),d("salt_100g"),d("saturated_fat_100g"),d("sodium_100g"),d("cholesterol_100g"),d("potassium_100g"),d("calcium_100g"),d("iron_100g"),d("caffeine_100g")), if(getColumnIndex("fetched_at")>=0)getLong(getColumnIndex("fetched_at"))else 0)
+private fun Cursor.toEntry()=FoodEntry(getLong(getColumnIndexOrThrow("id")),getLong(getColumnIndexOrThrow("consumed_at")),getDouble(getColumnIndexOrThrow("quantity_grams")),toProduct(),ns("entry_uuid").orEmpty(),ns("meal_type")?.let { runCatching{MealType.valueOf(it)}.getOrDefault(MealType.UNKNOWN)}?:MealType.UNKNOWN,ns("source")?.let { runCatching{FoodEntrySource.valueOf(it)}.getOrDefault(FoodEntrySource.UNKNOWN)}?:FoodEntrySource.UNKNOWN,ns("recipe_id"))
+private fun Cursor.s(n:String)=getString(getColumnIndexOrThrow(n)); private fun Cursor.ns(n:String)=getColumnIndex(n).takeIf{it>=0}?.let{if(isNull(it))null else getString(it)}; private fun Cursor.d(n:String)=getColumnIndex(n).takeIf{it>=0}?.let{if(isNull(it))null else getDouble(it)}; private fun Cursor.i(n:String)=getColumnIndex(n).takeIf{it>=0}?.let{if(isNull(it))null else getInt(it)}
+private inline fun <T> Cursor.rows(f:(Cursor)->T)=buildList { while(moveToNext()) add(f(this@rows)) }

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogStore.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodLogStore.kt
@@ -11,6 +11,11 @@ import java.util.UUID
 internal const val MIN_QUANTITY_GRAMS = 1.0
 internal const val MAX_QUANTITY_GRAMS = 5_000.0
 
+internal data class FoodLogDatabaseImportResult(
+    val insertedEntries: Int,
+    val reminders: List<FoodLogReminder>,
+)
+
 /** The entry table deliberately contains a full nutrition snapshot. Product edits never rewrite history. */
 internal class FoodLogStore(context: Context) : AutoCloseable {
     private val helper = FoodLogDatabase(context.applicationContext)
@@ -20,14 +25,21 @@ internal class FoodLogStore(context: Context) : AutoCloseable {
         return helper.readableDatabase.query("products", PRODUCT_COLUMNS, "barcode=?", arrayOf(normalized), null, null, null).use { if (it.moveToFirst()) it.toProduct() else null }
     }
     @Synchronized fun upsertProduct(product: FoodProduct) { helper.writableDatabase.insertWithOnConflict("products", null, product.values(), SQLiteDatabase.CONFLICT_REPLACE) }
-    @Synchronized fun createCustomFood(name: String, nutrients: NutrientsPer100g, brand: String = ""): FoodProduct {
+    @Synchronized fun createCustomFood(
+        name: String,
+        nutrients: NutrientsPer100g,
+        brand: String = "",
+    ): FoodProduct {
         require(name.isNotBlank() && name.length <= 300)
         return FoodProduct("custom-" + UUID.randomUUID(), name.trim(), brand.trim(), null, null, null, null, nutrients, System.currentTimeMillis()).also(::upsertProduct)
     }
     @Synchronized fun addEntry(product: FoodProduct, quantityGrams: Double, consumedAtMillis: Long = System.currentTimeMillis()): Long =
         addEntry(product, quantityGrams, consumedAtMillis, MealType.UNKNOWN, FoodEntrySource.UNKNOWN)
     @Synchronized fun addEntry(product: FoodProduct, quantityGrams: Double, consumedAtMillis: Long, mealType: MealType, source: FoodEntrySource, recipeId: String? = null, uuid: String = UUID.randomUUID().toString()): Long {
-        require(quantityGrams in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS); require(uuid.length in 1..64)
+        require(quantityGrams in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS)
+        require(consumedAtMillis > 0L)
+        require(FOOD_ENTRY_ID_PATTERN.matches(uuid))
+        require(recipeId == null || FOOD_UUID_PATTERN.matches(recipeId))
         val db = helper.writableDatabase; db.beginTransaction()
         return try { db.insertWithOnConflict("products", null, product.values(), SQLiteDatabase.CONFLICT_REPLACE)
             db.insertOrThrow("entries", null, product.values().apply { remove("fetched_at"); put("consumed_at", consumedAtMillis); put("quantity_grams", quantityGrams); put("entry_uuid", uuid); put("meal_type", mealType.name); put("source", source.name); putNullable("recipe_id", recipeId) }).also { db.setTransactionSuccessful() }
@@ -39,41 +51,289 @@ internal class FoodLogStore(context: Context) : AutoCloseable {
         return helper.readableDatabase.query("entries", ENTRY_COLUMNS, "consumed_at>=? AND consumed_at<=?", arrayOf(startMillis.toString(),endMillisInclusive.toString()),null,null,"consumed_at DESC,id DESC").use { it.rows(Cursor::toEntry) }
     }
     @Synchronized fun dailySummary(atMillis: Long = System.currentTimeMillis(), zoneId: ZoneId = ZoneId.systemDefault()) = aggregateNutrition(entriesForDay(atMillis, zoneId))
-    @Synchronized fun weeklySummary(atMillis: Long = System.currentTimeMillis(), zoneId: ZoneId = ZoneId.systemDefault()): DailyNutritionTotals { val b=dayBounds(atMillis,zoneId); return aggregateNutrition(entriesBetween(b.first - 6L*24*60*60*1000, b.last)) }
+    @Synchronized fun weeklySummary(
+        atMillis: Long = System.currentTimeMillis(),
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): DailyNutritionTotals {
+        val currentDate = java.time.Instant.ofEpochMilli(atMillis).atZone(zoneId).toLocalDate()
+        val start = currentDate.minusDays(6).atStartOfDay(zoneId).toInstant().toEpochMilli()
+        val end = dayBounds(atMillis, zoneId).last
+        return aggregateNutrition(entriesBetween(start, end))
+    }
+    @Synchronized fun dailySummariesForWeek(
+        atMillis: Long = System.currentTimeMillis(),
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): List<Pair<java.time.LocalDate, DailyNutritionTotals>> {
+        val currentDate = java.time.Instant.ofEpochMilli(atMillis).atZone(zoneId).toLocalDate()
+        return (6L downTo 0L).map { daysAgo ->
+            val date = currentDate.minusDays(daysAgo)
+            val midday = date.atTime(12, 0).atZone(zoneId).toInstant().toEpochMilli()
+            date to aggregateNutrition(entriesForDay(midday, zoneId))
+        }
+    }
+    @Synchronized fun allProducts(limit: Int = 500): List<FoodProduct> =
+        helper.readableDatabase.query(
+            "products",
+            PRODUCT_COLUMNS,
+            null,
+            null,
+            null,
+            null,
+            "product_name COLLATE NOCASE",
+            limit.coerceIn(1, 2_000).toString(),
+        ).use { it.rows(Cursor::toProduct) }
     @Synchronized fun recentProducts(limit: Int = 8): List<FoodProduct> = helper.readableDatabase.rawQuery("SELECT ${PRODUCT_COLUMNS.joinToString { "p.$it" }} FROM products p INNER JOIN entries e ON e.barcode=p.barcode GROUP BY p.barcode ORDER BY MAX(e.consumed_at) DESC LIMIT ?", arrayOf(limit.coerceIn(1,32).toString())).use { it.rows(Cursor::toProduct) }
     @Synchronized fun latestEntryForDay(atMillis: Long = System.currentTimeMillis()): FoodEntry? = entriesForDay(atMillis).firstOrNull()
+    @Synchronized fun entry(id: Long): FoodEntry? = helper.readableDatabase.query(
+        "entries",
+        ENTRY_COLUMNS,
+        "id=?",
+        arrayOf(id.toString()),
+        null,
+        null,
+        null,
+        "1",
+    ).use { if (it.moveToFirst()) it.toEntry() else null }
     @Synchronized fun deleteEntry(id: Long): Boolean = helper.writableDatabase.delete("entries", "id=?", arrayOf(id.toString())) == 1
+    @Synchronized fun deleteEntry(uuid: String): Boolean {
+        if (!FOOD_ENTRY_ID_PATTERN.matches(uuid)) return false
+        return helper.writableDatabase.delete("entries", "entry_uuid=?", arrayOf(uuid)) == 1
+    }
+    @Synchronized fun updateEntryMeal(uuid: String, mealType: MealType): Boolean {
+        if (!FOOD_ENTRY_ID_PATTERN.matches(uuid)) return false
+        return helper.writableDatabase.update(
+            "entries",
+            ContentValues().apply { put("meal_type", mealType.name) },
+            "entry_uuid=?",
+            arrayOf(uuid),
+        ) == 1
+    }
     @Synchronized fun setFavorite(barcode: String, favorite: Boolean) { val code=productId(barcode)?:return; if(favorite) helper.writableDatabase.insertWithOnConflict("favorites",null,ContentValues().apply{put("barcode",code)},SQLiteDatabase.CONFLICT_IGNORE) else helper.writableDatabase.delete("favorites","barcode=?",arrayOf(code)) }
     @Synchronized fun favoriteProducts(): List<FoodProduct> = helper.readableDatabase.rawQuery("SELECT ${PRODUCT_COLUMNS.joinToString()} FROM products WHERE barcode IN (SELECT barcode FROM favorites) ORDER BY product_name",null).use { it.rows(Cursor::toProduct) }
     @Synchronized fun saveGoals(goals: NutritionGoals) { helper.writableDatabase.insertWithOnConflict("goals",null,ContentValues().apply { put("singleton",1); putNullable("calories",goals.caloriesKcal);putNullable("protein",goals.proteinGrams);putNullable("carbohydrate",goals.carbohydrateGrams);putNullable("fat",goals.fatGrams) },SQLiteDatabase.CONFLICT_REPLACE) }
     @Synchronized fun goals(): NutritionGoals? = helper.readableDatabase.query("goals",arrayOf("calories","protein","carbohydrate","fat"),"singleton=1",null,null,null,null).use { if(it.moveToFirst()) NutritionGoals(it.d("calories"),it.d("protein"),it.d("carbohydrate"),it.d("fat")) else null }
-    @Synchronized fun saveRecipe(recipe: FoodRecipe) { val db=helper.writableDatabase; db.beginTransaction(); try { db.insertWithOnConflict("recipes",null,ContentValues().apply{put("recipe_uuid",recipe.uuid);put("name",recipe.name);put("servings",recipe.servings);put("created_at",recipe.createdAtMillis)},SQLiteDatabase.CONFLICT_REPLACE); db.delete("recipe_ingredients","recipe_uuid=?",arrayOf(recipe.uuid)); recipe.ingredients.forEach { i -> db.insertOrThrow("recipe_ingredients",null,ContentValues().apply { put("recipe_uuid",recipe.uuid);put("barcode",i.product.barcode);put("grams",i.grams) }) }; db.setTransactionSuccessful() } finally { db.endTransaction() } }
-    @Synchronized fun exportJson(): String = FoodLogBackup.encode(entriesBetween(0, Long.MAX_VALUE))
-    /** Validates the complete payload before opening the write transaction; UUIDs make merging idempotent. */
-    @Synchronized fun importJson(json: String): Int {
-        val entries = FoodLogBackup.decode(json)
-        val db = helper.writableDatabase; var inserted = 0; db.beginTransaction()
-        try { entries.forEach { entry ->
-            val exists = db.query("entries", arrayOf("id"), "entry_uuid=?", arrayOf(entry.uuid), null, null, null).use { it.moveToFirst() }
-            if (!exists) { db.insertWithOnConflict("products", null, entry.product.values(), SQLiteDatabase.CONFLICT_REPLACE)
-                db.insertOrThrow("entries", null, entry.product.values().apply { remove("fetched_at"); put("consumed_at",entry.consumedAtMillis);put("quantity_grams",entry.quantityGrams);put("entry_uuid",entry.uuid);put("meal_type",entry.mealType.name);put("source",entry.source.name);putNullable("recipe_id",entry.recipeId) }); inserted++ }
-        }; db.setTransactionSuccessful(); return inserted } finally { db.endTransaction() }
+    @Synchronized fun saveRecipe(recipe: FoodRecipe) {
+        val db = helper.writableDatabase
+        db.beginTransaction()
+        try {
+            recipe.ingredients.forEach { ingredient ->
+                db.insertWithOnConflict(
+                    "products",
+                    null,
+                    ingredient.product.values(),
+                    SQLiteDatabase.CONFLICT_REPLACE,
+                )
+            }
+            db.insertWithOnConflict(
+                "products",
+                null,
+                recipe.asProduct().values(),
+                SQLiteDatabase.CONFLICT_REPLACE,
+            )
+            db.insertWithOnConflict(
+                "recipes",
+                null,
+                ContentValues().apply {
+                    put("recipe_uuid", recipe.uuid)
+                    put("name", recipe.name)
+                    put("servings", recipe.servings)
+                    put("created_at", recipe.createdAtMillis)
+                },
+                SQLiteDatabase.CONFLICT_REPLACE,
+            )
+            db.delete("recipe_ingredients", "recipe_uuid=?", arrayOf(recipe.uuid))
+            recipe.ingredients.forEach { ingredient ->
+                db.insertOrThrow(
+                    "recipe_ingredients",
+                    null,
+                    ContentValues().apply {
+                        put("recipe_uuid", recipe.uuid)
+                        put("barcode", ingredient.product.barcode)
+                        put("grams", ingredient.grams)
+                    },
+                )
+            }
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
     }
+    @Synchronized fun recipes(): List<FoodRecipe> {
+        val db = helper.readableDatabase
+        return db.query(
+            "recipes",
+            arrayOf("recipe_uuid", "name", "servings", "created_at"),
+            null,
+            null,
+            null,
+            null,
+            "name COLLATE NOCASE",
+        ).use { recipesCursor ->
+            recipesCursor.rows { recipeCursor ->
+                val uuid = recipeCursor.s("recipe_uuid")
+                val ingredients = db.rawQuery(
+                    "SELECT ${PRODUCT_COLUMNS.joinToString { "p.$it" }}, ri.grams AS ingredient_grams " +
+                        "FROM recipe_ingredients ri INNER JOIN products p ON p.barcode=ri.barcode " +
+                        "WHERE ri.recipe_uuid=? ORDER BY p.product_name COLLATE NOCASE",
+                    arrayOf(uuid),
+                ).use { ingredientCursor ->
+                    ingredientCursor.rows {
+                        RecipeIngredient(it.toProduct(), it.getDouble(it.getColumnIndexOrThrow("ingredient_grams")))
+                    }
+                }
+                FoodRecipe(
+                    uuid = uuid,
+                    name = recipeCursor.s("name"),
+                    servings = recipeCursor.getDouble(recipeCursor.getColumnIndexOrThrow("servings")),
+                    ingredients = ingredients,
+                    createdAtMillis = recipeCursor.getLong(recipeCursor.getColumnIndexOrThrow("created_at")),
+                )
+            }
+        }
+    }
+    @Synchronized fun exportJson(reminders: List<FoodLogReminder>): String = FoodLogBackup.encode(
+        FoodLogArchive(
+            entries = entriesBetween(0, Long.MAX_VALUE),
+            products = allProductsForBackup(),
+            favoriteProductIds = favoriteProducts().mapTo(linkedSetOf(), FoodProduct::barcode),
+            goals = goals(),
+            recipes = recipes(),
+            reminders = reminders,
+        ),
+    )
+    /** Validates the complete payload before opening the write transaction; UUIDs make merging idempotent. */
+    @Synchronized fun importJson(json: String): FoodLogDatabaseImportResult {
+        val archive = FoodLogBackup.decode(json)
+        val db = helper.writableDatabase
+        var inserted = 0
+        db.beginTransaction()
+        try {
+            archive.products.forEach { product ->
+                db.insertWithOnConflict("products", null, product.values(), SQLiteDatabase.CONFLICT_REPLACE)
+            }
+            archive.entries.forEach { entry ->
+                val exists = db.query("entries", arrayOf("id"), "entry_uuid=?", arrayOf(entry.uuid), null, null, null).use { it.moveToFirst() }
+                if (!exists) {
+                    db.insertOrThrow("entries", null, entry.product.values().apply {
+                        remove("fetched_at")
+                        put("consumed_at", entry.consumedAtMillis)
+                        put("quantity_grams", entry.quantityGrams)
+                        put("entry_uuid", entry.uuid)
+                        put("meal_type", entry.mealType.name)
+                        put("source", entry.source.name)
+                        putNullable("recipe_id", entry.recipeId)
+                    })
+                    inserted++
+                }
+            }
+            archive.favoriteProductIds.forEach { barcode ->
+                db.insertWithOnConflict(
+                    "favorites",
+                    null,
+                    ContentValues().apply { put("barcode", barcode) },
+                    SQLiteDatabase.CONFLICT_IGNORE,
+                )
+            }
+            archive.goals?.let { importedGoals ->
+                db.insertWithOnConflict(
+                    "goals",
+                    null,
+                    ContentValues().apply {
+                        put("singleton", 1)
+                        putNullable("calories", importedGoals.caloriesKcal)
+                        putNullable("protein", importedGoals.proteinGrams)
+                        putNullable("carbohydrate", importedGoals.carbohydrateGrams)
+                        putNullable("fat", importedGoals.fatGrams)
+                    },
+                    SQLiteDatabase.CONFLICT_REPLACE,
+                )
+            }
+            archive.recipes.forEach { recipe ->
+                db.insertWithOnConflict(
+                    "recipes",
+                    null,
+                    ContentValues().apply {
+                        put("recipe_uuid", recipe.uuid)
+                        put("name", recipe.name)
+                        put("servings", recipe.servings)
+                        put("created_at", recipe.createdAtMillis)
+                    },
+                    SQLiteDatabase.CONFLICT_REPLACE,
+                )
+                db.delete("recipe_ingredients", "recipe_uuid=?", arrayOf(recipe.uuid))
+                recipe.ingredients.forEach { ingredient ->
+                    db.insertOrThrow(
+                        "recipe_ingredients",
+                        null,
+                        ContentValues().apply {
+                            put("recipe_uuid", recipe.uuid)
+                            put("barcode", ingredient.product.barcode)
+                            put("grams", ingredient.grams)
+                        },
+                    )
+                }
+                db.insertWithOnConflict("products", null, recipe.asProduct().values(), SQLiteDatabase.CONFLICT_REPLACE)
+            }
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+        return FoodLogDatabaseImportResult(inserted, archive.reminders)
+    }
+
+    private fun allProductsForBackup(): List<FoodProduct> = helper.readableDatabase.query(
+        "products",
+        PRODUCT_COLUMNS,
+        null,
+        null,
+        null,
+        null,
+        "product_name COLLATE NOCASE",
+    ).use { it.rows(Cursor::toProduct) }
     override fun close() = helper.close()
     private class FoodLogDatabase(context: Context): SQLiteOpenHelper(context,"food-log.db",null,2) {
         override fun onCreate(db: SQLiteDatabase) { createV1(db); upgradeTo2(db) }
         override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) { if(oldVersion < 2) upgradeTo2(db) }
-        private fun createV1(db: SQLiteDatabase) { db.execSQL("CREATE TABLE products (barcode TEXT PRIMARY KEY NOT NULL, product_name TEXT NOT NULL, brand TEXT NOT NULL, serving_label TEXT, serving_grams REAL, nutrition_grade TEXT, nova_group INTEGER, calories_100g REAL, protein_100g REAL, carbohydrate_100g REAL, fat_100g REAL, sugars_100g REAL, fiber_100g REAL, salt_100g REAL, fetched_at INTEGER NOT NULL)"); db.execSQL("CREATE TABLE entries (id INTEGER PRIMARY KEY AUTOINCREMENT, consumed_at INTEGER NOT NULL, quantity_grams REAL NOT NULL, barcode TEXT NOT NULL, product_name TEXT NOT NULL, brand TEXT NOT NULL, serving_label TEXT, serving_grams REAL, nutrition_grade TEXT, nova_group INTEGER, calories_100g REAL, protein_100g REAL, carbohydrate_100g REAL, fat_100g REAL, sugars_100g REAL, fiber_100g REAL, salt_100g REAL)"); db.execSQL("CREATE INDEX entries_consumed_at ON entries (consumed_at DESC)") }
+        private fun createV1(db: SQLiteDatabase) { db.execSQL("CREATE TABLE products (barcode TEXT PRIMARY KEY NOT NULL, product_name TEXT NOT NULL, brand TEXT NOT NULL, serving_label TEXT, serving_grams REAL, nutrition_grade TEXT, nova_group INTEGER, calories_100g REAL, protein_100g REAL, carbohydrate_100g REAL, fat_100g REAL, sugars_100g REAL, fiber_100g REAL, salt_100g REAL, fetched_at INTEGER NOT NULL)"); db.execSQL("CREATE TABLE entries (id INTEGER PRIMARY KEY AUTOINCREMENT, consumed_at INTEGER NOT NULL, quantity_grams REAL NOT NULL, barcode TEXT NOT NULL, product_name TEXT NOT NULL, brand TEXT NOT NULL, serving_label TEXT, serving_grams REAL, nutrition_grade TEXT, nova_group INTEGER, calories_100g REAL, protein_100g REAL, carbohydrate_100g REAL, fat_100g REAL, sugars_100g REAL, fiber_100g REAL, salt_100g REAL)"); db.execSQL("CREATE INDEX entries_consumed_at ON entries (consumed_at DESC)"); db.execSQL("CREATE INDEX entries_barcode ON entries (barcode)") }
         private fun upgradeTo2(db: SQLiteDatabase) { listOf("saturated_fat_100g REAL","sodium_100g REAL","cholesterol_100g REAL","potassium_100g REAL","calcium_100g REAL","iron_100g REAL","caffeine_100g REAL").forEach { c -> db.execSQL("ALTER TABLE products ADD COLUMN $c"); db.execSQL("ALTER TABLE entries ADD COLUMN $c") }; db.execSQL("ALTER TABLE entries ADD COLUMN entry_uuid TEXT"); db.execSQL("ALTER TABLE entries ADD COLUMN meal_type TEXT NOT NULL DEFAULT 'UNKNOWN'"); db.execSQL("ALTER TABLE entries ADD COLUMN source TEXT NOT NULL DEFAULT 'UNKNOWN'"); db.execSQL("ALTER TABLE entries ADD COLUMN recipe_id TEXT"); db.execSQL("UPDATE entries SET entry_uuid = lower(hex(randomblob(16))) WHERE entry_uuid IS NULL"); db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS entries_uuid ON entries(entry_uuid)"); db.execSQL("CREATE TABLE IF NOT EXISTS favorites (barcode TEXT PRIMARY KEY NOT NULL)"); db.execSQL("CREATE TABLE IF NOT EXISTS goals (singleton INTEGER PRIMARY KEY CHECK(singleton=1), calories REAL, protein REAL, carbohydrate REAL, fat REAL)"); db.execSQL("CREATE TABLE IF NOT EXISTS recipes (recipe_uuid TEXT PRIMARY KEY NOT NULL, name TEXT NOT NULL, servings REAL NOT NULL, created_at INTEGER NOT NULL)"); db.execSQL("CREATE TABLE IF NOT EXISTS recipe_ingredients (recipe_uuid TEXT NOT NULL, barcode TEXT NOT NULL, grams REAL NOT NULL, PRIMARY KEY(recipe_uuid, barcode))") }
     }
     private companion object { val PRODUCT_COLUMNS=arrayOf("barcode","product_name","brand","serving_label","serving_grams","nutrition_grade","nova_group","calories_100g","protein_100g","carbohydrate_100g","fat_100g","sugars_100g","fiber_100g","salt_100g","saturated_fat_100g","sodium_100g","cholesterol_100g","potassium_100g","calcium_100g","iron_100g","caffeine_100g","fetched_at"); val ENTRY_COLUMNS=arrayOf("id","consumed_at","quantity_grams","entry_uuid","meal_type","source","recipe_id",*PRODUCT_COLUMNS.filterNot { it=="fetched_at" }.toTypedArray()) }
 }
 private fun FoodProduct.values()=ContentValues().apply { put("barcode",barcode);put("product_name",name);put("brand",brand);putNullable("serving_label",servingLabel);putNullable("serving_grams",servingGrams);putNullable("nutrition_grade",nutritionGrade);putNullable("nova_group",novaGroup); listOf("calories_100g" to nutrients.caloriesKcal,"protein_100g" to nutrients.proteinGrams,"carbohydrate_100g" to nutrients.carbohydrateGrams,"fat_100g" to nutrients.fatGrams,"sugars_100g" to nutrients.sugarsGrams,"fiber_100g" to nutrients.fiberGrams,"salt_100g" to nutrients.saltGrams,"saturated_fat_100g" to nutrients.saturatedFatGrams,"sodium_100g" to nutrients.sodiumMilligrams,"cholesterol_100g" to nutrients.cholesterolMilligrams,"potassium_100g" to nutrients.potassiumMilligrams,"calcium_100g" to nutrients.calciumMilligrams,"iron_100g" to nutrients.ironMilligrams,"caffeine_100g" to nutrients.caffeineMilligrams).forEach{putNullable(it.first,it.second)};put("fetched_at",fetchedAtMillis) }
-internal fun productId(value: String): String? = normalizeBarcode(value) ?: value.takeIf { it.matches(Regex("custom-[A-Za-z0-9-]{1,64}")) }
+internal fun productId(value: String): String? = normalizeBarcode(value)
+    ?: value.takeIf { it.matches(Regex("(?:custom|recipe)-[A-Za-z0-9-]{1,64}")) }
 private fun ContentValues.putNullable(k:String,v:String?){if(v==null)putNull(k)else put(k,v)}
 private fun ContentValues.putNullable(k:String,v:Double?){if(v==null)putNull(k)else put(k,v)}
 private fun ContentValues.putNullable(k:String,v:Int?){if(v==null)putNull(k)else put(k,v)}
-private fun Cursor.toProduct()=FoodProduct(s("barcode"),s("product_name"),s("brand"),ns("serving_label"),d("serving_grams"),ns("nutrition_grade"),i("nova_group"),NutrientsPer100g(d("calories_100g"),d("protein_100g"),d("carbohydrate_100g"),d("fat_100g"),d("sugars_100g"),d("fiber_100g"),d("salt_100g"),d("saturated_fat_100g"),d("sodium_100g"),d("cholesterol_100g"),d("potassium_100g"),d("calcium_100g"),d("iron_100g"),d("caffeine_100g")), if(getColumnIndex("fetched_at")>=0)getLong(getColumnIndex("fetched_at"))else 0)
+private fun Cursor.toProduct(): FoodProduct {
+    val fetchedAtIndex = getColumnIndex("fetched_at")
+    return FoodProduct(
+        s("barcode"),
+        s("product_name"),
+        s("brand"),
+        ns("serving_label"),
+        d("serving_grams"),
+        ns("nutrition_grade"),
+        i("nova_group"),
+        NutrientsPer100g(
+            d("calories_100g"),
+            d("protein_100g"),
+            d("carbohydrate_100g"),
+            d("fat_100g"),
+            d("sugars_100g"),
+            d("fiber_100g"),
+            d("salt_100g"),
+            d("saturated_fat_100g"),
+            d("sodium_100g"),
+            d("cholesterol_100g"),
+            d("potassium_100g"),
+            d("calcium_100g"),
+            d("iron_100g"),
+            d("caffeine_100g"),
+        ),
+        if (fetchedAtIndex >= 0) getLong(fetchedAtIndex) else 0L,
+    )
+}
 private fun Cursor.toEntry()=FoodEntry(getLong(getColumnIndexOrThrow("id")),getLong(getColumnIndexOrThrow("consumed_at")),getDouble(getColumnIndexOrThrow("quantity_grams")),toProduct(),ns("entry_uuid").orEmpty(),ns("meal_type")?.let { runCatching{MealType.valueOf(it)}.getOrDefault(MealType.UNKNOWN)}?:MealType.UNKNOWN,ns("source")?.let { runCatching{FoodEntrySource.valueOf(it)}.getOrDefault(FoodEntrySource.UNKNOWN)}?:FoodEntrySource.UNKNOWN,ns("recipe_id"))
 private fun Cursor.s(n:String)=getString(getColumnIndexOrThrow(n)); private fun Cursor.ns(n:String)=getColumnIndex(n).takeIf{it>=0}?.let{if(isNull(it))null else getString(it)}; private fun Cursor.d(n:String)=getColumnIndex(n).takeIf{it>=0}?.let{if(isNull(it))null else getDouble(it)}; private fun Cursor.i(n:String)=getColumnIndex(n).takeIf{it>=0}?.let{if(isNull(it))null else getInt(it)}
 private inline fun <T> Cursor.rows(f:(Cursor)->T)=buildList { while(moveToNext()) add(f(this@rows)) }

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodModels.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodModels.kt
@@ -23,7 +23,13 @@ internal data class NutrientsPer100g(
     val caffeineMilligrams: Double? = null,
 )
 
-internal enum class MealType { BREAKFAST, LUNCH, DINNER, SNACK, UNKNOWN }
+internal enum class MealType(val displayName: String) {
+    BREAKFAST("Breakfast"),
+    LUNCH("Lunch"),
+    DINNER("Dinner"),
+    SNACK("Snack"),
+    UNKNOWN("Unassigned"),
+}
 
 internal enum class FoodEntrySource { SCANNED, SEARCHED, CUSTOM, RECIPE, IMPORTED, UNKNOWN }
 
@@ -32,9 +38,20 @@ internal data class NutritionGoals(
     val proteinGrams: Double? = null,
     val carbohydrateGrams: Double? = null,
     val fatGrams: Double? = null,
-)
+) {
+    init {
+        require(caloriesKcal == null || caloriesKcal in 1.0..20_000.0)
+        require(proteinGrams == null || proteinGrams in 1.0..2_000.0)
+        require(carbohydrateGrams == null || carbohydrateGrams in 1.0..3_000.0)
+        require(fatGrams == null || fatGrams in 1.0..2_000.0)
+    }
+}
 
-internal data class RecipeIngredient(val product: FoodProduct, val grams: Double)
+internal data class RecipeIngredient(val product: FoodProduct, val grams: Double) {
+    init {
+        require(grams in MIN_QUANTITY_GRAMS..MAX_RECIPE_INGREDIENT_GRAMS)
+    }
+}
 
 internal data class FoodRecipe(
     val uuid: String,
@@ -43,8 +60,30 @@ internal data class FoodRecipe(
     val ingredients: List<RecipeIngredient>,
     val createdAtMillis: Long,
 ) {
-    init { require(uuid.isNotBlank()); require(name.isNotBlank()); require(servings > 0.0); require(ingredients.isNotEmpty()) }
+    init {
+        require(uuid.matches(FOOD_UUID_PATTERN))
+        require(name.isNotBlank() && name.length <= MAX_RECIPE_NAME_CHARS)
+        require(servings in 0.25..100.0)
+        require(ingredients.size in 1..MAX_RECIPE_INGREDIENTS)
+        require(ingredients.map { it.product.barcode }.toSet().size == ingredients.size)
+    }
+
+    val totalIngredientGrams: Double
+        get() = ingredients.sumOf(RecipeIngredient::grams)
+
     fun nutrientsPerServing(): NutrientsPer100g = nutrientsForIngredients(ingredients, servings)
+
+    fun asProduct(fetchedAtMillis: Long = createdAtMillis): FoodProduct = FoodProduct(
+        barcode = "recipe-$uuid",
+        name = name,
+        brand = "Recipe",
+        servingLabel = "1 serving",
+        servingGrams = totalIngredientGrams / servings,
+        nutritionGrade = null,
+        novaGroup = null,
+        nutrients = nutrientsForIngredients(ingredients, totalIngredientGrams / 100.0),
+        fetchedAtMillis = fetchedAtMillis,
+    )
 }
 
 internal data class FoodProduct(
@@ -167,3 +206,21 @@ internal fun dayBounds(
     val endExclusive = date.plusDays(1).atStartOfDay(zoneId).toInstant().toEpochMilli()
     return start until endExclusive
 }
+
+internal fun inferredMealType(
+    atMillis: Long,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+): MealType = when (Instant.ofEpochMilli(atMillis).atZone(zoneId).hour) {
+    in 5..10 -> MealType.BREAKFAST
+    in 11..15 -> MealType.LUNCH
+    in 16..21 -> MealType.DINNER
+    else -> MealType.SNACK
+}
+
+internal val FOOD_UUID_PATTERN = Regex(
+    "[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+)
+internal val FOOD_ENTRY_ID_PATTERN = Regex("(?:${FOOD_UUID_PATTERN.pattern}|[0-9a-f]{32})")
+internal const val MAX_RECIPE_NAME_CHARS = 120
+internal const val MAX_RECIPE_INGREDIENTS = 64
+internal const val MAX_RECIPE_INGREDIENT_GRAMS = 20_000.0

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodModels.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodModels.kt
@@ -1,0 +1,106 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.time.Instant
+import java.time.ZoneId
+import java.util.Locale
+
+internal data class NutrientsPer100g(
+    val caloriesKcal: Double?,
+    val proteinGrams: Double?,
+    val carbohydrateGrams: Double?,
+    val fatGrams: Double?,
+    val sugarsGrams: Double?,
+    val fiberGrams: Double?,
+    val saltGrams: Double?,
+)
+
+internal data class FoodProduct(
+    val barcode: String,
+    val name: String,
+    val brand: String,
+    val servingLabel: String?,
+    val servingGrams: Double?,
+    val nutritionGrade: String?,
+    val novaGroup: Int?,
+    val nutrients: NutrientsPer100g,
+    val fetchedAtMillis: Long,
+)
+
+internal data class FoodEntry(
+    val id: Long,
+    val consumedAtMillis: Long,
+    val quantityGrams: Double,
+    val product: FoodProduct,
+)
+
+internal data class NutritionTotal(
+    val knownValue: Double,
+    val complete: Boolean,
+)
+
+internal data class DailyNutritionTotals(
+    val entryCount: Int,
+    val caloriesKcal: NutritionTotal,
+    val proteinGrams: NutritionTotal,
+    val carbohydrateGrams: NutritionTotal,
+    val fatGrams: NutritionTotal,
+)
+
+internal fun aggregateNutrition(entries: List<FoodEntry>): DailyNutritionTotals = DailyNutritionTotals(
+    entryCount = entries.size,
+    caloriesKcal = aggregate(entries) { it.product.nutrients.caloriesKcal },
+    proteinGrams = aggregate(entries) { it.product.nutrients.proteinGrams },
+    carbohydrateGrams = aggregate(entries) { it.product.nutrients.carbohydrateGrams },
+    fatGrams = aggregate(entries) { it.product.nutrients.fatGrams },
+)
+
+private fun aggregate(
+    entries: List<FoodEntry>,
+    value: (FoodEntry) -> Double?,
+): NutritionTotal {
+    var sum = 0.0
+    var complete = true
+    entries.forEach { entry ->
+        val per100g = value(entry)
+        if (per100g == null) {
+            complete = false
+        } else {
+            sum += per100g * entry.quantityGrams / 100.0
+        }
+    }
+    return NutritionTotal(sum, complete)
+}
+
+internal fun scaledValue(per100g: Double?, quantityGrams: Double): Double? =
+    per100g?.times(quantityGrams)?.div(100.0)
+
+internal fun NutritionTotal.display(unit: String): String = when {
+    !complete && knownValue == 0.0 -> "unknown"
+    !complete -> "≥ ${formatNutritionNumber(knownValue)} $unit"
+    else -> "${formatNutritionNumber(knownValue)} $unit"
+}
+
+internal fun Double?.displayPer100g(unit: String): String =
+    this?.let { "${formatNutritionNumber(it)} $unit" } ?: "unknown"
+
+internal fun formatNutritionNumber(value: Double): String {
+    val symbols = DecimalFormatSymbols.getInstance(Locale.getDefault())
+    return DecimalFormat("0.#", symbols).format(value.coerceAtLeast(0.0))
+}
+
+internal fun normalizeBarcode(raw: String): String? {
+    val normalized = raw.filter(Char::isDigit)
+    return normalized.takeIf { it.length in 4..14 }
+}
+
+internal fun dayBounds(
+    atMillis: Long,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+): LongRange {
+    val date = Instant.ofEpochMilli(atMillis).atZone(zoneId).toLocalDate()
+    val start = date.atStartOfDay(zoneId).toInstant().toEpochMilli()
+    val endExclusive = date.plusDays(1).atStartOfDay(zoneId).toInstant().toEpochMilli()
+    return start until endExclusive
+}

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodModels.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodModels.kt
@@ -14,7 +14,38 @@ internal data class NutrientsPer100g(
     val sugarsGrams: Double?,
     val fiberGrams: Double?,
     val saltGrams: Double?,
+    val saturatedFatGrams: Double? = null,
+    val sodiumMilligrams: Double? = null,
+    val cholesterolMilligrams: Double? = null,
+    val potassiumMilligrams: Double? = null,
+    val calciumMilligrams: Double? = null,
+    val ironMilligrams: Double? = null,
+    val caffeineMilligrams: Double? = null,
 )
+
+internal enum class MealType { BREAKFAST, LUNCH, DINNER, SNACK, UNKNOWN }
+
+internal enum class FoodEntrySource { SCANNED, SEARCHED, CUSTOM, RECIPE, IMPORTED, UNKNOWN }
+
+internal data class NutritionGoals(
+    val caloriesKcal: Double? = null,
+    val proteinGrams: Double? = null,
+    val carbohydrateGrams: Double? = null,
+    val fatGrams: Double? = null,
+)
+
+internal data class RecipeIngredient(val product: FoodProduct, val grams: Double)
+
+internal data class FoodRecipe(
+    val uuid: String,
+    val name: String,
+    val servings: Double,
+    val ingredients: List<RecipeIngredient>,
+    val createdAtMillis: Long,
+) {
+    init { require(uuid.isNotBlank()); require(name.isNotBlank()); require(servings > 0.0); require(ingredients.isNotEmpty()) }
+    fun nutrientsPerServing(): NutrientsPer100g = nutrientsForIngredients(ingredients, servings)
+}
 
 internal data class FoodProduct(
     val barcode: String,
@@ -33,6 +64,10 @@ internal data class FoodEntry(
     val consumedAtMillis: Long,
     val quantityGrams: Double,
     val product: FoodProduct,
+    val uuid: String = "",
+    val mealType: MealType = MealType.UNKNOWN,
+    val source: FoodEntrySource = FoodEntrySource.UNKNOWN,
+    val recipeId: String? = null,
 )
 
 internal data class NutritionTotal(
@@ -46,6 +81,13 @@ internal data class DailyNutritionTotals(
     val proteinGrams: NutritionTotal,
     val carbohydrateGrams: NutritionTotal,
     val fatGrams: NutritionTotal,
+    val saturatedFatGrams: NutritionTotal = NutritionTotal(0.0, true),
+    val sodiumMilligrams: NutritionTotal = NutritionTotal(0.0, true),
+    val cholesterolMilligrams: NutritionTotal = NutritionTotal(0.0, true),
+    val potassiumMilligrams: NutritionTotal = NutritionTotal(0.0, true),
+    val calciumMilligrams: NutritionTotal = NutritionTotal(0.0, true),
+    val ironMilligrams: NutritionTotal = NutritionTotal(0.0, true),
+    val caffeineMilligrams: NutritionTotal = NutritionTotal(0.0, true),
 )
 
 internal fun aggregateNutrition(entries: List<FoodEntry>): DailyNutritionTotals = DailyNutritionTotals(
@@ -54,7 +96,28 @@ internal fun aggregateNutrition(entries: List<FoodEntry>): DailyNutritionTotals 
     proteinGrams = aggregate(entries) { it.product.nutrients.proteinGrams },
     carbohydrateGrams = aggregate(entries) { it.product.nutrients.carbohydrateGrams },
     fatGrams = aggregate(entries) { it.product.nutrients.fatGrams },
+    saturatedFatGrams = aggregate(entries) { it.product.nutrients.saturatedFatGrams },
+    sodiumMilligrams = aggregate(entries) { it.product.nutrients.sodiumMilligrams },
+    cholesterolMilligrams = aggregate(entries) { it.product.nutrients.cholesterolMilligrams },
+    potassiumMilligrams = aggregate(entries) { it.product.nutrients.potassiumMilligrams },
+    calciumMilligrams = aggregate(entries) { it.product.nutrients.calciumMilligrams },
+    ironMilligrams = aggregate(entries) { it.product.nutrients.ironMilligrams },
+    caffeineMilligrams = aggregate(entries) { it.product.nutrients.caffeineMilligrams },
 )
+
+internal fun nutrientsForIngredients(ingredients: List<RecipeIngredient>, servings: Double): NutrientsPer100g {
+    require(servings > 0.0)
+    fun value(selector: (NutrientsPer100g) -> Double?): Double? {
+        var unknown = false; var total = 0.0
+        ingredients.forEach { ingredient ->
+            if (ingredient.grams <= 0.0) unknown = true
+            val v = selector(ingredient.product.nutrients)
+            if (v == null) unknown = true else total += v * ingredient.grams / 100.0
+        }
+        return if (unknown) null else total / servings
+    }
+    return NutrientsPer100g(value { it.caloriesKcal }, value { it.proteinGrams }, value { it.carbohydrateGrams }, value { it.fatGrams }, value { it.sugarsGrams }, value { it.fiberGrams }, value { it.saltGrams }, value { it.saturatedFatGrams }, value { it.sodiumMilligrams }, value { it.cholesterolMilligrams }, value { it.potassiumMilligrams }, value { it.calciumMilligrams }, value { it.ironMilligrams }, value { it.caffeineMilligrams })
+}
 
 private fun aggregate(
     entries: List<FoodEntry>,

--- a/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodVoiceParser.kt
+++ b/plugins/foodlog/src/main/java/com/anezium/rokidbus/plugin/foodlog/FoodVoiceParser.kt
@@ -1,0 +1,96 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import java.text.Normalizer
+import java.util.Locale
+
+internal sealed interface FoodVoiceMatch {
+    data class Matched(
+        val product: FoodProduct,
+        val quantityGrams: Double,
+    ) : FoodVoiceMatch
+
+    data class Ambiguous(val products: List<FoodProduct>) : FoodVoiceMatch
+    data object NoProduct : FoodVoiceMatch
+    data object InvalidQuantity : FoodVoiceMatch
+}
+
+/**
+ * Resolves intentionally narrow phrases such as "200 grams of rice" or
+ * "200 grammes de riz" against products already stored on the phone. It does
+ * not invent nutrition data or send the transcript to another service.
+ */
+internal object FoodVoiceParser {
+    private val quantityPrefix = Regex(
+        pattern = """^\s*(\d{1,4}(?:[.,]\d)?)\s*(?:g|gr|gram|grams|gramme|grammes)\s+(?:(?:of|de|d')\s*)?(.+?)\s*$""",
+        option = RegexOption.IGNORE_CASE,
+    )
+    private val amountLessPrefix = Regex(
+        pattern = """^\s*(?:add|log|eat|mange|manger|ajoute|ajouter)\s+(?:(?:some|du|de la|des|un|une)\s+)?(.+?)\s*$""",
+        option = RegexOption.IGNORE_CASE,
+    )
+
+    fun match(transcript: String, candidates: List<FoodProduct>): FoodVoiceMatch {
+        if (candidates.isEmpty()) return FoodVoiceMatch.NoProduct
+        val parsed = parsePhrase(transcript)
+        if (parsed.quantityGrams != null && parsed.quantityGrams !in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS) {
+            return FoodVoiceMatch.InvalidQuantity
+        }
+        val query = normalizeSearch(parsed.productQuery)
+        if (query.isBlank()) return FoodVoiceMatch.NoProduct
+
+        val ranked = candidates
+            .distinctBy(FoodProduct::barcode)
+            .map { product -> product to score(query, product) }
+            .filter { (_, score) -> score > 0 }
+            .sortedWith(compareByDescending<Pair<FoodProduct, Int>> { it.second }.thenBy { it.first.name })
+        val bestScore = ranked.firstOrNull()?.second ?: return FoodVoiceMatch.NoProduct
+        val best = ranked.filter { it.second == bestScore }.map(Pair<FoodProduct, Int>::first)
+        if (best.size > 1) return FoodVoiceMatch.Ambiguous(best.take(MAX_AMBIGUOUS_RESULTS))
+
+        val product = best.single()
+        val quantity = parsed.quantityGrams
+            ?: product.servingGrams?.takeIf { it in MIN_QUANTITY_GRAMS..MAX_QUANTITY_GRAMS }
+            ?: DEFAULT_VOICE_QUANTITY_GRAMS
+        return FoodVoiceMatch.Matched(product, quantity)
+    }
+
+    private fun parsePhrase(transcript: String): ParsedPhrase {
+        quantityPrefix.matchEntire(transcript)?.let { match ->
+            return ParsedPhrase(
+                quantityGrams = match.groupValues[1].replace(',', '.').toDoubleOrNull(),
+                productQuery = match.groupValues[2],
+            )
+        }
+        val query = amountLessPrefix.matchEntire(transcript)?.groupValues?.get(1) ?: transcript
+        return ParsedPhrase(quantityGrams = null, productQuery = query)
+    }
+
+    private fun score(query: String, product: FoodProduct): Int {
+        val name = normalizeSearch(product.name)
+        val brand = normalizeSearch(product.brand)
+        return when {
+            name == query -> 100
+            "$brand $name".trim() == query -> 95
+            name.startsWith(query) -> 80
+            name.contains(query) -> 70
+            query.contains(name) -> 60
+            brand.isNotBlank() && "$brand $name".contains(query) -> 50
+            else -> 0
+        }
+    }
+
+    private fun normalizeSearch(value: String): String = Normalizer
+        .normalize(value, Normalizer.Form.NFD)
+        .replace(Regex("\\p{M}+"), "")
+        .lowercase(Locale.ROOT)
+        .replace(Regex("[^a-z0-9]+"), " ")
+        .trim()
+
+    private data class ParsedPhrase(
+        val quantityGrams: Double?,
+        val productQuery: String,
+    )
+
+    private const val DEFAULT_VOICE_QUANTITY_GRAMS = 100.0
+    private const val MAX_AMBIGUOUS_RESULTS = 4
+}

--- a/plugins/foodlog/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/plugins/foodlog/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/nexus_glyph_foodlog"
+    android:inset="20%" />

--- a/plugins/foodlog/src/main/res/drawable/nexus_glyph_foodlog.xml
+++ b/plugins/foodlog/src/main/res/drawable/nexus_glyph_foodlog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF4DFF8C"
+        android:pathData="M12,21.2L10.55,19.88C5.4,15.2 2,12.11 2,8.32C2,5.23 4.42,2.8 7.5,2.8C9.24,2.8 10.91,3.61 12,4.89C13.09,3.61 14.76,2.8 16.5,2.8C19.58,2.8 22,5.23 22,8.32C22,12.11 18.6,15.2 13.45,19.88Z" />
+</vector>

--- a/plugins/foodlog/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/plugins/foodlog/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/plugins/foodlog/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/plugins/foodlog/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/plugins/foodlog/src/main/res/values/ic_launcher_background.xml
+++ b/plugins/foodlog/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#030C06</color>
+</resources>

--- a/plugins/foodlog/src/main/res/values/strings.xml
+++ b/plugins/foodlog/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Nexus Food Log Plugin</string>
+</resources>

--- a/plugins/foodlog/src/main/res/values/styles.xml
+++ b/plugins/foodlog/src/main/res/values/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.FoodLog" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:fontFamily">sans</item>
+        <item name="android:colorAccent">#71FF97</item>
+        <item name="android:windowBackground">#030C06</item>
+        <item name="android:statusBarColor">#030C06</item>
+        <item name="android:navigationBarColor">#030C06</item>
+    </style>
+</resources>

--- a/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodFactsClientTest.kt
+++ b/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodFactsClientTest.kt
@@ -1,0 +1,107 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FoodFactsClientTest {
+    @Test
+    fun parseProduct_keepsTheProductNutritionSnapshot() {
+        val product = FoodFactsClient.parseProduct(
+            json = """
+                {
+                  "product": {
+                    "code": "3 012345 678901",
+                    "product_name": "  Oat bar  ",
+                    "brands": " Example Foods ",
+                    "serving_size": "1 bar (40 g)",
+                    "serving_quantity": 40,
+                    "serving_quantity_unit": "g",
+                    "nutrition_grades": "b",
+                    "nova_group": 3,
+                    "nutriments": {
+                      "energy-kcal_100g": 425,
+                      "proteins_100g": 9.5,
+                      "carbohydrates_100g": 61,
+                      "fat_100g": 16,
+                      "sugars_100g": 21,
+                      "fiber_100g": 7.2,
+                      "salt_100g": 0.42
+                    }
+                  }
+                }
+            """.trimIndent(),
+            fallbackBarcode = "0000000000000",
+            fetchedAtMillis = 1_700_000_000_000L,
+        )
+
+        requireNotNull(product)
+        assertEquals("3012345678901", product.barcode)
+        assertEquals("Oat bar", product.name)
+        assertEquals("Example Foods", product.brand)
+        assertEquals("1 bar (40 g)", product.servingLabel)
+        assertEquals(40.0, product.servingGrams!!, 0.0)
+        assertEquals("b", product.nutritionGrade)
+        assertEquals(3, product.novaGroup)
+        assertEquals(425.0, product.nutrients.caloriesKcal!!, 0.0)
+        assertEquals(1_700_000_000_000L, product.fetchedAtMillis)
+    }
+
+    @Test
+    fun parseProduct_preservesMissingNutrientsAsUnknown() {
+        val product = FoodFactsClient.parseProduct(
+            json = """{"product":{"code":"12345678","nutriments":{"fat_100g":0}}}""",
+            fallbackBarcode = "87654321",
+            fetchedAtMillis = 42L,
+        )
+
+        requireNotNull(product)
+        assertEquals("Product 12345678", product.name)
+        assertNull(product.nutrients.caloriesKcal)
+        assertNull(product.nutrients.proteinGrams)
+        assertNull(product.nutrients.carbohydrateGrams)
+        assertEquals(0.0, product.nutrients.fatGrams!!, 0.0)
+        assertNull(product.servingGrams)
+        assertNull(product.nutritionGrade)
+        assertNull(product.novaGroup)
+    }
+
+    @Test
+    fun parseProduct_usesFallbackBarcodeAndRejectsAbsentProduct() {
+        val fallback = FoodFactsClient.parseProduct(
+            json = """{"product":{"generic_name":"Plain yogurt"}}""",
+            fallbackBarcode = " 978-0201379624 ",
+            fetchedAtMillis = 12L,
+        )
+
+        requireNotNull(fallback)
+        assertEquals("9780201379624", fallback.barcode)
+        assertEquals("Plain yogurt", fallback.name)
+        assertNull(
+            FoodFactsClient.parseProduct(
+                json = """{"status":0,"status_verbose":"product not found"}""",
+                fallbackBarcode = "12345678",
+                fetchedAtMillis = 12L,
+            ),
+        )
+    }
+
+    @Test
+    fun parseProduct_rejectsInvalidAndNonGramServingValues() {
+        val product = FoodFactsClient.parseProduct(
+            json = """
+                {"product":{"code":"12345678","serving_quantity":250,
+                "serving_quantity_unit":"ml","nova_group":7,
+                "nutriments":{"energy-kcal_100g":-3,"proteins_100g":"not a number"}}}
+            """.trimIndent(),
+            fallbackBarcode = "00000000",
+            fetchedAtMillis = 12L,
+        )
+
+        requireNotNull(product)
+        assertNull(product.servingGrams)
+        assertNull(product.novaGroup)
+        assertNull(product.nutrients.caloriesKcal)
+        assertNull(product.nutrients.proteinGrams)
+    }
+}

--- a/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderPlannerTest.kt
+++ b/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderPlannerTest.kt
@@ -1,0 +1,24 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FoodLogReminderPlannerTest {
+    @Test fun `future reminder schedules at its requested wall time`() {
+        val plan = FoodLogReminderPlanner.plan(reminder(2_000L), 1_000L) as FoodLogAlarmPlan.Schedule
+        assertEquals(2_000L, plan.triggerAtMillis)
+    }
+    @Test fun `passed reminder is delivered immediately`() {
+        assertTrue(FoodLogReminderPlanner.plan(reminder(1_000L), 1_000L) is FoodLogAlarmPlan.DeliverImmediately)
+    }
+    @Test fun `scheduler passes exact permission through and has no retry loop`() {
+        val gateway = RecordingGateway()
+        val scheduler = FoodLogReminderScheduler(gateway, { false }, { 1_000L })
+        assertFalse(scheduler.schedule(reminder(2_000L)))
+        assertEquals(1, gateway.scheduled)
+    }
+    private fun reminder(epoch: Long) = FoodLogReminder("00000000-0000-4000-8000-000000000001", FoodLogReminderKind.MEAL, "Lunch", epoch, true)
+    private class RecordingGateway : FoodLogAlarmGateway { var scheduled = 0; override fun schedule(id: String, triggerAtMillis: Long, exact: Boolean): Boolean { scheduled++; return exact }; override fun cancel(id: String) = Unit; override fun deliverNow(id: String, late: Boolean) = Unit }
+}

--- a/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderPlannerTest.kt
+++ b/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderPlannerTest.kt
@@ -19,6 +19,24 @@ class FoodLogReminderPlannerTest {
         assertFalse(scheduler.schedule(reminder(2_000L)))
         assertEquals(1, gateway.scheduled)
     }
+    @Test fun `restored overdue reminder is marked late without direct delivery`() {
+        val gateway = RecordingGateway()
+        val scheduler = FoodLogReminderScheduler(gateway, { true }, { 2_000L })
+        scheduler.reschedule(reminder(1_000L))
+        assertEquals(true, gateway.lastLate)
+        assertEquals(0, gateway.delivered)
+    }
     private fun reminder(epoch: Long) = FoodLogReminder("00000000-0000-4000-8000-000000000001", FoodLogReminderKind.MEAL, "Lunch", epoch, true)
-    private class RecordingGateway : FoodLogAlarmGateway { var scheduled = 0; override fun schedule(id: String, triggerAtMillis: Long, exact: Boolean): Boolean { scheduled++; return exact }; override fun cancel(id: String) = Unit; override fun deliverNow(id: String, late: Boolean) = Unit }
+    private class RecordingGateway : FoodLogAlarmGateway {
+        var scheduled = 0
+        var delivered = 0
+        var lastLate = false
+        override fun schedule(id: String, triggerAtMillis: Long, exact: Boolean, late: Boolean): Boolean {
+            scheduled++
+            lastLate = late
+            return exact
+        }
+        override fun cancel(id: String) = Unit
+        override fun deliverNow(id: String, late: Boolean) { delivered++ }
+    }
 }

--- a/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderStoreTest.kt
+++ b/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderStoreTest.kt
@@ -2,6 +2,7 @@ package com.anezium.rokidbus.plugin.foodlog
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -19,5 +20,33 @@ class FoodLogReminderStoreTest {
     }
     @Test(expected = IllegalArgumentException::class) fun `labels are bounded`() {
         FoodLogReminderStore(temporary.root).create(FoodLogReminderKind.MEAL, " ", 1L)
+    }
+    @Test fun `backup merge is idempotent by stable UUID`() {
+        val id = "00000000-0000-4000-8000-000000000001"
+        val store = FoodLogReminderStore(temporary.root)
+        val reminder = FoodLogReminder(id, FoodLogReminderKind.MEAL, "Dinner", 3_000L, true)
+        store.merge(listOf(reminder))
+        store.merge(listOf(reminder.copy(label = "Late dinner")))
+        assertEquals(1, store.all().size)
+        assertEquals("Late dinner", store.get(id)?.label)
+    }
+    @Test fun `corrupt reminder state fails closed`() {
+        java.io.File(temporary.root, "food_log_reminders_v1.json").writeText("not-json")
+        val result = runCatching { FoodLogReminderStore(temporary.root).all() }
+        assertTrue(result.isFailure)
+    }
+    @Test fun `valid backup merge quarantines corrupt state before recovery`() {
+        java.io.File(temporary.root, "food_log_reminders_v1.json").writeText("not-json")
+        val reminder = FoodLogReminder(
+            "00000000-0000-4000-8000-000000000001",
+            FoodLogReminderKind.HYDRATION,
+            "Water",
+            4_000L,
+            true,
+        )
+        val store = FoodLogReminderStore(temporary.root)
+        store.merge(listOf(reminder))
+        assertEquals(reminder, store.all().single())
+        assertTrue(temporary.root.listFiles().orEmpty().any { it.name.startsWith("food_log_reminders_v1.json.corrupt-") })
     }
 }

--- a/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderStoreTest.kt
+++ b/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodLogReminderStoreTest.kt
@@ -1,0 +1,23 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class FoodLogReminderStoreTest {
+    @get:Rule val temporary = TemporaryFolder()
+    @Test fun `create update exact delete and delivery claim are atomic`() {
+        val store = FoodLogReminderStore(temporary.root, { "00000000-0000-4000-8000-000000000001" })
+        val saved = store.create(FoodLogReminderKind.HYDRATION, "Water", 2_000L)
+        assertEquals(saved, store.get(saved.id))
+        assertEquals(true, store.update(saved.copy(enabled = false)))
+        assertNull(store.takeForDelivery(saved.id))
+        assertEquals(saved.copy(enabled = false), store.cancel(saved.id))
+        assertNull(store.cancel(saved.id))
+    }
+    @Test(expected = IllegalArgumentException::class) fun `labels are bounded`() {
+        FoodLogReminderStore(temporary.root).create(FoodLogReminderKind.MEAL, " ", 1L)
+    }
+}

--- a/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodModelsTest.kt
+++ b/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodModelsTest.kt
@@ -10,6 +10,20 @@ import java.time.ZoneId
 
 class FoodModelsTest {
     @Test
+    fun recipe_calculatesPerServingFromIngredientSnapshots() {
+        val recipe = FoodRecipe("recipe-1", "Oats", 2.0, listOf(RecipeIngredient(product(nutrients = NutrientsPer100g(100.0, 10.0, 20.0, 5.0, null, null, null)), 200.0)), 1L)
+        assertEquals(100.0, recipe.nutrientsPerServing().caloriesKcal!!, 0.0)
+        assertEquals(10.0, recipe.nutrientsPerServing().proteinGrams!!, 0.0)
+    }
+
+    @Test
+    fun backup_roundTripAndRejectsDuplicateStableUuid() {
+        val entry = FoodEntry(1, 100, 50.0, product(nutrients = NutrientsPer100g(1.0, null, null, null, null, null, null)), "entry-1")
+        assertEquals("entry-1", FoodLogBackup.decode(FoodLogBackup.encode(listOf(entry))).single().uuid)
+        val duplicated = "{\"schemaVersion\":2,\"entries\":[" + FoodLogBackup.encode(listOf(entry)).let { org.json.JSONObject(it).getJSONArray("entries").getJSONObject(0) } + "," + FoodLogBackup.encode(listOf(entry)).let { org.json.JSONObject(it).getJSONArray("entries").getJSONObject(0) } + "]}"
+        try { FoodLogBackup.decode(duplicated); throw AssertionError("Expected validation failure") } catch (_: IllegalArgumentException) { }
+    }
+    @Test
     fun normalizeBarcode_keepsDigitsAndEnforcesSupportedLengths() {
         assertEquals("3012345678901", normalizeBarcode(" 3-012345 678901 "))
         assertEquals("1234", normalizeBarcode("1 2 3 4"))

--- a/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodModelsTest.kt
+++ b/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodModelsTest.kt
@@ -11,17 +11,51 @@ import java.time.ZoneId
 class FoodModelsTest {
     @Test
     fun recipe_calculatesPerServingFromIngredientSnapshots() {
-        val recipe = FoodRecipe("recipe-1", "Oats", 2.0, listOf(RecipeIngredient(product(nutrients = NutrientsPer100g(100.0, 10.0, 20.0, 5.0, null, null, null)), 200.0)), 1L)
+        val recipe = FoodRecipe("123e4567-e89b-12d3-a456-426614174000", "Oats", 2.0, listOf(RecipeIngredient(product(nutrients = NutrientsPer100g(100.0, 10.0, 20.0, 5.0, null, null, null)), 200.0)), 1L)
         assertEquals(100.0, recipe.nutrientsPerServing().caloriesKcal!!, 0.0)
         assertEquals(10.0, recipe.nutrientsPerServing().proteinGrams!!, 0.0)
     }
 
     @Test
-    fun backup_roundTripAndRejectsDuplicateStableUuid() {
-        val entry = FoodEntry(1, 100, 50.0, product(nutrients = NutrientsPer100g(1.0, null, null, null, null, null, null)), "entry-1")
-        assertEquals("entry-1", FoodLogBackup.decode(FoodLogBackup.encode(listOf(entry))).single().uuid)
-        val duplicated = "{\"schemaVersion\":2,\"entries\":[" + FoodLogBackup.encode(listOf(entry)).let { org.json.JSONObject(it).getJSONArray("entries").getJSONObject(0) } + "," + FoodLogBackup.encode(listOf(entry)).let { org.json.JSONObject(it).getJSONArray("entries").getJSONObject(0) } + "]}"
+    fun backup_roundTripsTheV3ArchiveAndRejectsDuplicateStableUuid() {
+        val product = product(nutrients = NutrientsPer100g(1.0, null, null, null, null, null, null))
+        val entryUuid = "123e4567-e89b-12d3-a456-426614174001"
+        val recipeUuid = "123e4567-e89b-12d3-a456-426614174002"
+        val reminderUuid = "123e4567-e89b-12d3-a456-426614174003"
+        val entry = FoodEntry(1, 100, 50.0, product, entryUuid, MealType.LUNCH, FoodEntrySource.CUSTOM)
+        val archive = FoodLogArchive(
+            entries = listOf(entry),
+            products = listOf(product),
+            favoriteProductIds = setOf(product.barcode),
+            goals = NutritionGoals(2_000.0, 120.0, 250.0, 70.0),
+            recipes = listOf(FoodRecipe(recipeUuid, "Lunch", 1.0, listOf(RecipeIngredient(product, 50.0)), 100L)),
+            reminders = listOf(FoodLogReminder(reminderUuid, FoodLogReminderKind.MEAL, "Lunch", 200L, true)),
+        )
+
+        val decoded = FoodLogBackup.decode(FoodLogBackup.encode(archive))
+
+        assertEquals(entryUuid, decoded.entries.single().uuid)
+        assertEquals("50 g", decoded.products.single().servingLabel)
+        assertEquals(setOf(product.barcode), decoded.favoriteProductIds)
+        assertEquals(2_000.0, decoded.goals!!.caloriesKcal!!, 0.0)
+        assertEquals(recipeUuid, decoded.recipes.single().uuid)
+        assertEquals(reminderUuid, decoded.reminders.single().id)
+
+        val encodedEntry = org.json.JSONObject(FoodLogBackup.encode(archive))
+            .getJSONArray("entries")
+            .getJSONObject(0)
+        val duplicated = "{\"schemaVersion\":2,\"entries\":[$encodedEntry,$encodedEntry]}"
         try { FoodLogBackup.decode(duplicated); throw AssertionError("Expected validation failure") } catch (_: IllegalArgumentException) { }
+    }
+
+    @Test
+    fun backup_rejectsUnknownEntryEnums() {
+        val product = product(nutrients = NutrientsPer100g(1.0, null, null, null, null, null, null))
+        val entry = FoodEntry(1, 100, 50.0, product, "123e4567-e89b-12d3-a456-426614174001")
+        val json = org.json.JSONObject(FoodLogBackup.encode(FoodLogArchive(listOf(entry), listOf(product), emptySet(), null, emptyList(), emptyList())))
+        json.getJSONArray("entries").getJSONObject(0).put("mealType", "BRUNCH")
+
+        try { FoodLogBackup.decode(json.toString()); throw AssertionError("Expected validation failure") } catch (_: IllegalArgumentException) { }
     }
     @Test
     fun normalizeBarcode_keepsDigitsAndEnforcesSupportedLengths() {

--- a/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodModelsTest.kt
+++ b/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodModelsTest.kt
@@ -1,0 +1,96 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneId
+
+class FoodModelsTest {
+    @Test
+    fun normalizeBarcode_keepsDigitsAndEnforcesSupportedLengths() {
+        assertEquals("3012345678901", normalizeBarcode(" 3-012345 678901 "))
+        assertEquals("1234", normalizeBarcode("1 2 3 4"))
+        assertEquals("12345678901234", normalizeBarcode("12345678901234"))
+        assertNull(normalizeBarcode("123"))
+        assertNull(normalizeBarcode("123456789012345"))
+        assertNull(normalizeBarcode("not a barcode"))
+    }
+
+    @Test
+    fun scaledValue_returnsUnknownWithoutPer100gValue() {
+        assertEquals(84.0, scaledValue(210.0, 40.0)!!, 0.0)
+        assertEquals(0.0, scaledValue(0.0, 250.0)!!, 0.0)
+        assertNull(scaledValue(null, 40.0))
+    }
+
+    @Test
+    fun aggregateNutrition_scalesSnapshotValuesAndMarksIncompleteTotals() {
+        val complete = product(
+            nutrients = NutrientsPer100g(200.0, 10.0, 30.0, 5.0, null, null, null),
+        )
+        val missingProtein = product(
+            barcode = "12345679",
+            nutrients = NutrientsPer100g(100.0, null, 20.0, 0.0, null, null, null),
+        )
+
+        val totals = aggregateNutrition(
+            listOf(
+                FoodEntry(1L, 10L, 150.0, complete),
+                FoodEntry(2L, 20L, 50.0, missingProtein),
+            ),
+        )
+
+        assertEquals(2, totals.entryCount)
+        assertEquals(350.0, totals.caloriesKcal.knownValue, 0.0)
+        assertTrue(totals.caloriesKcal.complete)
+        assertEquals(15.0, totals.proteinGrams.knownValue, 0.0)
+        assertFalse(totals.proteinGrams.complete)
+        assertEquals(55.0, totals.carbohydrateGrams.knownValue, 0.0)
+        assertEquals(7.5, totals.fatGrams.knownValue, 0.0)
+        assertEquals("≥ 15 g", totals.proteinGrams.display("g"))
+    }
+
+    @Test
+    fun aggregateNutrition_displaysAllUnknownNutrientsAsUnknownInsteadOfZero() {
+        val product = product(
+            nutrients = NutrientsPer100g(null, null, null, null, null, null, null),
+        )
+
+        val totals = aggregateNutrition(listOf(FoodEntry(1L, 10L, 80.0, product)))
+
+        assertEquals(0.0, totals.caloriesKcal.knownValue, 0.0)
+        assertFalse(totals.caloriesKcal.complete)
+        assertEquals("unknown", totals.caloriesKcal.display("kcal"))
+    }
+
+    @Test
+    fun dayBounds_usesTheLocalDayAcrossSpringDstChange() {
+        val paris = ZoneId.of("Europe/Paris")
+        val atMillis = Instant.parse("2026-03-29T12:00:00Z").toEpochMilli()
+
+        val bounds = dayBounds(atMillis, paris)
+
+        assertEquals(Instant.parse("2026-03-28T23:00:00Z").toEpochMilli(), bounds.first)
+        assertEquals(23L * 60L * 60L * 1000L, bounds.last - bounds.first + 1)
+        assertTrue(Instant.parse("2026-03-29T21:59:59.999Z").toEpochMilli() in bounds)
+        assertFalse(Instant.parse("2026-03-29T22:00:00Z").toEpochMilli() in bounds)
+    }
+
+    private fun product(
+        barcode: String = "12345678",
+        nutrients: NutrientsPer100g,
+    ) = FoodProduct(
+        barcode = barcode,
+        name = "Snapshot product",
+        brand = "Brand",
+        servingLabel = "50 g",
+        servingGrams = 50.0,
+        nutritionGrade = null,
+        novaGroup = null,
+        nutrients = nutrients,
+        fetchedAtMillis = 1L,
+    )
+}

--- a/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodVoiceParserTest.kt
+++ b/plugins/foodlog/src/test/java/com/anezium/rokidbus/plugin/foodlog/FoodVoiceParserTest.kt
@@ -1,0 +1,61 @@
+package com.anezium.rokidbus.plugin.foodlog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class FoodVoiceParserTest {
+    private val rice = product("Riz", servingGrams = 180.0)
+    private val yogurt = product("Greek yogurt", brand = "Example", barcode = "12345679")
+
+    @Test
+    fun `matches French phrase with an explicit amount`() {
+        val result = FoodVoiceParser.match("200 grammes de riz", listOf(rice))
+
+        require(result is FoodVoiceMatch.Matched)
+        assertSame(rice, result.product)
+        assertEquals(200.0, result.quantityGrams, 0.0)
+    }
+
+    @Test
+    fun `matches English phrase without accents or case sensitivity`() {
+        val result = FoodVoiceParser.match("ADD some GREEK YOGURT", listOf(rice, yogurt))
+
+        require(result is FoodVoiceMatch.Matched)
+        assertSame(yogurt, result.product)
+        assertEquals(100.0, result.quantityGrams, 0.0)
+    }
+
+    @Test
+    fun `uses the stored serving when amount is omitted`() {
+        val result = FoodVoiceParser.match("mange du riz", listOf(rice))
+
+        require(result is FoodVoiceMatch.Matched)
+        assertEquals(180.0, result.quantityGrams, 0.0)
+    }
+
+    @Test
+    fun `rejects amounts outside journal bounds`() {
+        assertSame(
+            FoodVoiceMatch.InvalidQuantity,
+            FoodVoiceParser.match("9000 g riz", listOf(rice)),
+        )
+    }
+
+    private fun product(
+        name: String,
+        brand: String = "",
+        barcode: String = "12345678",
+        servingGrams: Double? = null,
+    ) = FoodProduct(
+        barcode = barcode,
+        name = name,
+        brand = brand,
+        servingLabel = null,
+        servingGrams = servingGrams,
+        nutritionGrade = null,
+        novaGroup = null,
+        nutrients = NutrientsPer100g(null, null, null, null, null, null, null),
+        fetchedAtMillis = 0L,
+    )
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(":phone-client-probe")
 include(":glasses-client-probe")
 include(":plugin-sample")
 include(":plugin-wireless-adb")
+include(":plugin-foodlog")
 include(":ink-engine")
 
 // Plugin modules live under plugins/ (one folder per plugin, each with its own
@@ -50,6 +51,7 @@ project(":plugin-photosync").projectDir = file("plugins/photosync")
 project(":plugin-relay").projectDir = file("plugins/relay")
 project(":plugin-sample").projectDir = file("plugins/sample")
 project(":plugin-wireless-adb").projectDir = file("plugins/wireless-adb")
+project(":plugin-foodlog").projectDir = file("plugins/foodlog")
 
 val cxrGlobalDirectory = file("../CxrGlobal")
 val skipCxrGlobal = providers.gradleProperty("skipCxrGlobal")


### PR DESCRIPTION
## What changed

- Add a first-party `plugin-foodlog` module for glasses barcode scanning and exact Open Food Facts lookups.
- Add a local-first phone dashboard with meal tracking, nutrition snapshots, micronutrients, goals, seven-day summaries, custom foods, favorites, and recipes.
- Add local voice logging from stored foods without retaining transcripts.
- Add optional write-only Health Connect synchronization, including meal updates and exact record removal after local deletion while opted in.
- Add explicit one-shot meal and hydration reminders with pause, resume, cancel, exact-alarm fallback, and boot restoration.
- Add bounded V3 JSON archive export/import for entries, products, favorites, goals, recipes, and reminders, with V2 import compatibility.

## Why

Food Log turns Nexus into a practical local-first food and nutrition tracker on both the glasses and phone, while keeping food history on-device unless the wearer explicitly exports it or enables Health Connect.

## User impact

After installing and approving the new `surfaces`, `camera`, and `stt` capabilities, users can scan or voice-log food from the glasses and manage their full journal from the phone settings surface. Health Connect and reminder permissions remain optional and are requested at the point of use.

## Validation

- `./gradlew :plugin-foodlog:testDebugUnitTest :plugin-foodlog:assembleDebug -PskipCxrGlobal=true`
- `./gradlew :plugin-foodlog:lintDebug -PskipCxrGlobal=true`
- 25 unit tests pass
- Debug APK assembled as version `3.0.0` / version code `3`